### PR TITLE
Add support for privy hpke and by extension user JWTs in the ctx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,12 +509,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -507,6 +577,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dabb6555f92fb9ee4140454eb5dcd14c7960e1225c6d1a6cc361f032947713e"
 
 [[package]]
 name = "constant_time_eq"
@@ -564,6 +640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -575,6 +652,15 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array",
  "subtle",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -670,7 +756,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -708,7 +794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common",
  "subtle",
 ]
@@ -797,6 +883,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -1076,6 +1163,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1244,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1280,27 @@ dependencies = [
  "digest 0.9.0",
  "generic-array",
  "hmac 0.8.1",
+]
+
+[[package]]
+name = "hpke"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest 0.10.7",
+ "generic-array",
+ "hkdf",
+ "hmac 0.12.1",
+ "p256",
+ "rand_core 0.9.3",
+ "sha2 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
 ]
 
 [[package]]
@@ -1402,6 +1529,15 @@ checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1848,6 +1984,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,21 +2054,28 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.7",
+ "bincode",
+ "const-oid 0.10.1",
  "delegate",
+ "der",
  "dotenv",
  "futures",
  "hex",
+ "hpke",
  "p256",
  "privy-api",
  "progenitor-client",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "reqwest",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
  "sha2 0.10.9",
  "solana-sdk",
+ "spki",
  "test-case",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2008,6 +2174,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2204,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2043,6 +2229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2589,7 +2784,7 @@ dependencies = [
  "ark-serialize",
  "bytemuck",
  "solana-define-syscall",
- "thiserror 2.0.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -2791,7 +2986,7 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
- "thiserror 2.0.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -3272,7 +3467,7 @@ dependencies = [
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-vote-interface",
- "thiserror 2.0.16",
+ "thiserror",
  "wasm-bindgen",
 ]
 
@@ -3499,7 +3694,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error",
  "solana-validator-exit",
- "thiserror 2.0.16",
+ "thiserror",
  "wasm-bindgen",
 ]
 
@@ -3552,7 +3747,7 @@ dependencies = [
  "borsh 1.5.7",
  "libsecp256k1",
  "solana-define-syscall",
- "thiserror 2.0.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -4047,31 +4242,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.16",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4304,6 +4479,16 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "uriparse"
@@ -4775,6 +4960,16 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,22 @@ base64 = "0.21"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
-thiserror = "1.0"
+thiserror = "2.0.16"
 async-trait = "0.1"
 tracing = "0.1.41"
 progenitor-client = "0.11.0"
 delegate = "0.13.4"
-p256 = { version = "0.13.2", features = ["pem", "ecdsa"] }
+p256 = { version = "0.13.2", features = ["pem", "ecdsa", "pkcs8"] }
 futures = "0.3.31"
 serde_json_canonicalizer = "0.3.1"
 sha2 = "0.10.9"
 hex = "0.4"
+bincode = "1.3"
+hpke = "0.13.0"
+rand = "0.9.2"
+spki = { version = "0.7", features = ["std", "alloc"] }
+der = { version = "0.7", features = ["std", "alloc"] }
+const-oid = { version = "0.10.1", features = ["db"] }
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -34,6 +40,9 @@ dotenv = "0.15"
 uuid = { version = "1.0", features = ["v4"] }
 test-case = "3.3.1"
 tracing-test = "0.2.5"
+
+# used for deterministic key generation under testing
+rand_chacha = "0.9.0"
 
 [[example]]
 doc-scrape-examples = true

--- a/examples/jwt_authentication.rs
+++ b/examples/jwt_authentication.rs
@@ -1,0 +1,54 @@
+//! custom authorization example
+//!
+//! Enterprise customers may use external authorization providers to
+//! authorize users. To do so, they register a subject on a user record
+//! on Privy, then, a valid JWT for that subject can be used in exchange
+//! for a short lived authorization key.
+
+use anyhow::Result;
+use privy_api::types::builder::AuthenticateBody;
+use privy_rust::PrivyClient;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    // Get credentials from environment
+    let app_id = std::env::var("PRIVY_APP_ID").expect("PRIVY_APP_ID environment variable not set");
+    let app_secret =
+        std::env::var("PRIVY_APP_SECRET").expect("PRIVY_APP_SECRET environment variable not set");
+
+    tracing::info!(
+        "initializing privy with app_id: {}, app_secret: {}",
+        app_id,
+        app_secret,
+    );
+
+    let client = PrivyClient::new(app_id, app_secret)?;
+
+    let wallet = match client
+        .authenticate()
+        .body(AuthenticateBody::default().user_jwt("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGV4QGFybHlvbi5kZXYiLCJpYXQiOjEwMDAwMDAwMDAwMH0.IpNgavH95CFZPjkzQW4eyxMIfJ-O_5cIaDyu_6KRXffykjYDRwxTgFJuYq0F6d8wSXf4de-vzfBRWSKMISM3rJdlhximYINGJB14mJFCD87VMLFbTpHIXcv7hc1AAYMPGhOsRkYfYXuvVopKszMvhupmQYJ1npSvKWNeBniIyOHYv4xebZD8L0RVlPvuEKTXTu-CDfs2rMwvD9g_wiBznS3uMF3v_KPaY6x0sx9zeCSxAH9zvhMMtct_Ad9kuoUncGpRzNhEk6JlVccN2Leb1JzbldxSywyS2AApD05u-GFAgFDN3P39V3qgRTGDuuUfUvKQ9S4rbu5El9Qq1CJTeA"))
+        .send()
+        .await
+    {
+        Ok(r) => Ok(r.into_inner()),
+        Err(privy_api::Error::UnexpectedResponse(response)) => {
+            tracing::error!("unexpected response {:?}", response.text().await);
+            Err(privy_api::Error::Custom("whoops".to_string()))
+        }
+        Err(e) => {
+            tracing::error!("error {:?}", e);
+            Err(e)
+        }
+    }?;
+
+    tracing::info!("got new user: {:?}", wallet);
+
+    Ok(())
+}

--- a/examples/update_wallet.rs
+++ b/examples/update_wallet.rs
@@ -1,12 +1,17 @@
 //! Example usage - demonstrates how to use the Privy signer with tk-rs interface
 
+use std::sync::Arc;
+
 use anyhow::Result;
 use base64::{Engine, engine::general_purpose::STANDARD};
+use futures::TryStreamExt;
 use privy_api::types::{
-    PublicKeyOwner,
+    PublicKeyOwner, UserOwner,
     builder::{OwnerInput, UpdateWalletBody},
 };
-use privy_rust::{IntoKey, IntoSignature, PrivyApiError, PrivyClient};
+use privy_rust::{
+    AuthorizationContext, IntoKey, JwtUser, PrivateKeyFromFile, PrivyApiError, PrivyClient,
+};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -23,26 +28,27 @@ async fn main() -> Result<()> {
         std::env::var("PRIVY_APP_SECRET").expect("PRIVY_APP_SECRET environment variable not set");
     let wallet_id =
         std::env::var("PRIVY_WALLET_ID").expect("PRIVY_WALLET_ID environment variable not set");
-    let public_key =
-        std::env::var("PRIVY_PUBLIC_KEY").expect("PRIVY_PUBLIC_KEY environment variable not set");
 
     tracing::info!(
-        "initializing privy with app_id: {}, app_secret: {}, wallet_id: {}, public_key: {}",
+        "initializing privy with app_id: {}, app_secret: {}, wallet_id: {}",
         app_id,
         app_secret,
         wallet_id,
-        public_key
     );
 
     let client = PrivyClient::new(app_id.clone(), app_secret)?;
 
+    let key = PrivateKeyFromFile("private_key.pem".into());
+    let public_key = key.get_key().await?.public_key();
+
+    let client = Arc::new(client);
+    let mut ctx = AuthorizationContext::new();
+    ctx.push(PrivateKeyFromFile("private_key.pem".into()));
+    ctx.push(JwtUser(client.clone(), "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGV4QGFybHlvbi5kZXYiLCJpYXQiOjEwMDAwMDAwMDAwMH0.IpNgavH95CFZPjkzQW4eyxMIfJ-O_5cIaDyu_6KRXffykjYDRwxTgFJuYq0F6d8wSXf4de-vzfBRWSKMISM3rJdlhximYINGJB14mJFCD87VMLFbTpHIXcv7hc1AAYMPGhOsRkYfYXuvVopKszMvhupmQYJ1npSvKWNeBniIyOHYv4xebZD8L0RVlPvuEKTXTu-CDfs2rMwvD9g_wiBznS3uMF3v_KPaY6x0sx9zeCSxAH9zvhMMtct_Ad9kuoUncGpRzNhEk6JlVccN2Leb1JzbldxSywyS2AApD05u-GFAgFDN3P39V3qgRTGDuuUfUvKQ9S4rbu5El9Qq1CJTeA".to_string()));
+
     let wallet = client.get_wallet().wallet_id(&wallet_id).send().await?;
 
     tracing::info!("got wallet: {:?}", wallet);
-
-    let key_source = privy_rust::PrivateKeyFromFile("private_key.pem".into());
-    let key = key_source.get_key().await.unwrap();
-    let public_key = key.public_key();
 
     // Create the request body that will be sent using the generated privy-api type
     let update_wallet_body: privy_api::types::UpdateWalletBody = UpdateWalletBody::default()
@@ -51,6 +57,10 @@ async fn main() -> Result<()> {
                 .subtype_0(PublicKeyOwner {
                     public_key: public_key.to_string(),
                 })
+                // OwnerInput::default()
+                //     .subtype_1(UserOwner {
+                //         user_id: "did:privy:cmf5wqe2l0005k10blt7x5dq2".to_string(),
+                //     })
                 .try_into()?,
         ))
         .try_into()?;
@@ -66,23 +76,21 @@ async fn main() -> Result<()> {
     tracing::info!("canonical request data: {}", canonical_data);
 
     // Sign the canonical request data (UTF-8 bytes)
-    let signature = key_source.sign(canonical_data.as_bytes()).await.unwrap();
-
-    // Convert signature to DER format and then base64 encode
-    let der_bytes = signature.to_der();
-    let privy_authorization_signature = STANDARD.encode(&der_bytes);
-
-    tracing::debug!(
-        "Generated authorization signature: {} bytes DER -> {} chars base64",
-        der_bytes.len(),
-        privy_authorization_signature.len()
-    );
+    let signature = ctx
+        .sign(canonical_data.as_bytes())
+        .map_ok(|s| {
+            let der_bytes = s.to_der();
+            STANDARD.encode(&der_bytes)
+        })
+        .try_collect::<Vec<_>>()
+        .await?
+        .join(",");
 
     let wallet = match client
         .update_wallet()
         .wallet_id(wallet_id)
         .body(update_wallet_body)
-        .privy_authorization_signature(privy_authorization_signature)
+        .privy_authorization_signature(signature)
         .send()
         .await
     {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,8 +44,16 @@ pub enum KeyError {
     Unknown,
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("Invalid key format")]
+    #[error("Invalid key format: {0}")]
     InvalidFormat(String),
+    #[error("Base64 decoding failed: {0}")]
+    Base64(#[from] base64::DecodeError),
+    #[error("HPKE decryption failed: {0}")]
+    HpkeDecryption(String),
+    #[error("PKCS#8 parsing failed")]
+    Pkcs8Parsing,
+    #[error("Unsupported encryption type")]
+    UnsupportedEncryption,
 }
 
 #[derive(Error, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,13 @@ pub mod client;
 
 pub(crate) mod errors;
 pub(crate) mod keys;
+pub(crate) mod privy_hpke;
 pub(crate) mod types;
 
 pub use client::PrivyClient;
 pub use errors::*;
 pub use keys::*;
+pub use privy_hpke::PrivyHpke;
 pub use types::*;
 
 pub(crate) fn get_auth_header(app_id: &str, app_secret: &str) -> String {

--- a/src/privy_hpke.rs
+++ b/src/privy_hpke.rs
@@ -1,0 +1,373 @@
+use base64::Engine;
+use hpke::Deserializable;
+use hpke::{
+    Kem, OpModeR, Serializable, aead::ChaCha20Poly1305, kdf::HkdfSha256, kem::DhP256HkdfSha256,
+};
+use p256::{PublicKey, elliptic_curve::SecretKey, pkcs8::DecodePrivateKey};
+use spki::EncodePublicKey;
+
+use crate::KeyError;
+
+/// An ephemeral HPKE (Hybrid Public Key Encryption) manager for secure key exchange with the Privy API.
+///
+/// # Overview
+///
+/// This struct implements a complete HPKE client for Privy's JWT authentication exchange system.
+/// It generates an ephemeral P-256 keypair and handles the cryptographic handshake required to
+/// securely obtain temporary authorization keys from Privy's backend.
+///
+/// The HPKE exchange follows this flow:
+/// 1. **Client Setup**: Generate ephemeral P-256 keypair
+/// 2. **Key Advertisement**: Send SPKI-formatted public key to Privy API
+/// 3. **Server Response**: Receive encapsulated key + encrypted authorization key
+/// 4. **Key Decryption**: Use HPKE to decrypt the authorization key
+/// 5. **Key Parsing**: Parse the decrypted PKCS#8 DER key for signing operations
+///
+/// # Cryptographic Specifications
+///
+/// The implementation follows RFC 9180 HPKE specification with these exact algorithms:
+/// - **KEM (Key Encapsulation Mechanism)**: DHKEM(P-256, HKDF-SHA256)
+/// - **KDF (Key Derivation Function)**: HKDF-SHA256
+/// - **AEAD (Authenticated Encryption)**: `ChaCha20Poly1305`
+/// - **Curve**: NIST P-256 (secp256r1)
+/// - **Key Format**: SPKI (Subject Public Key Info) for advertisement
+/// - **Decrypted Key Format**: PKCS#8 DER encoded private keys
+///
+/// # Usage Pattern
+///
+/// ```rust,no_run
+/// use privy_rust::PrivyHpke;
+/// use privy_api::types::WithEncryptionEncryptedAuthorizationKey;
+///
+/// # async fn get_encrypted_authorization_key() -> WithEncryptionEncryptedAuthorizationKey {
+/// #     todo!()
+/// # }
+///
+/// # async fn jwt_exchange_example() -> Result<(), Box<dyn std::error::Error>> {
+/// // 1. Create ephemeral HPKE manager
+/// let hpke = PrivyHpke::new();
+///
+/// // 2. Get public key for API request
+/// let recipient_public_key = hpke.public_key()?;
+///
+/// // 3. Send to Privy API with JWT
+/// let encrypted_authorization_key = get_encrypted_authorization_key().await;
+///
+/// // 4. Decrypt the authorization key
+/// let auth_key = hpke.decrypt(
+///     &encrypted_authorization_key.encapsulated_key,
+///     &encrypted_authorization_key.ciphertext
+/// )?;
+///
+/// // 5. Use auth_key for wallet signing operations
+/// # Ok(())
+/// # }
+/// ```
+pub struct PrivyHpke {
+    /// The ephemeral HPKE private key used for decryption operations.
+    ///
+    /// This key is generated fresh for each JWT exchange and is never persisted.
+    /// It's used in conjunction with Privy's encapsulated key to derive the
+    /// shared secret for decrypting authorization keys.
+    private_key: <DhP256HkdfSha256 as Kem>::PrivateKey,
+
+    /// The corresponding HPKE public key sent to Privy's API.
+    ///
+    /// This key is formatted as SPKI and base64-encoded before transmission.
+    /// Privy uses this key to perform HPKE encryption of authorization keys,
+    /// ensuring only this specific client can decrypt the response.
+    public_key: <DhP256HkdfSha256 as Kem>::PublicKey,
+}
+
+impl PrivyHpke {
+    /// Creates a new ephemeral HPKE manager with a cryptographically secure P-256 keypair.
+    #[must_use]
+    pub fn new() -> Self {
+        let mut rng = rand::rng();
+        let (private_key, public_key) = DhP256HkdfSha256::gen_keypair(&mut rng);
+        Self {
+            private_key,
+            public_key,
+        }
+    }
+
+    /// Replace the cryptographic entropy source with a custom seed and a fast PRNG.
+    ///
+    /// # Security
+    /// This should only be used for testing purposes.
+    #[cfg(test)]
+    pub(crate) fn new_with_seed(seed: u64) -> Self {
+        use rand::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
+        let (private_key, public_key) = DhP256HkdfSha256::gen_keypair(&mut rng);
+        Self {
+            private_key,
+            public_key,
+        }
+    }
+
+    /// Formats the public key as a base64-encoded SPKI structure for Privy API requests.
+    ///
+    /// Uses the `RustCrypto` ecosystem (p256 + spki crates) to generate a standards-compliant
+    /// DER-encoded Subject Public Key Info structure. This approach is:
+    /// - **Correct by Construction**: Guaranteed ASN.1/DER compliance
+    /// - **Secure**: Peer-reviewed cryptographic libraries
+    /// - **Maintainable**: High-level, declarative API
+    ///
+    /// # SPKI Format Details
+    ///
+    /// The returned SPKI follows X.509 standards and is compatible with:
+    /// - Privy's Java SDK using `BouncyCastle`'s `SubjectPublicKeyInfo.getInstance()`
+    /// - OpenSSL's P-256 SPKI format
+    /// - RFC 5480 Elliptic Curve Cryptography Subject Public Key Info
+    ///
+    /// # Return Format
+    ///
+    /// Returns a base64-encoded string (RFC 4648) of the DER-encoded SPKI structure.
+    /// Example output: `MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE...`
+    ///
+    /// # Errors
+    ///
+    /// Returns a `KeyError::InvalidFormat` if:
+    /// - The internal public key cannot be serialized to SEC1 format
+    /// - SEC1 bytes cannot be parsed as a valid P-256 point
+    /// - SPKI DER encoding fails
+    /// - Base64 encoding fails
+    pub fn public_key(&self) -> Result<String, KeyError> {
+        // 1. Extract the raw SEC1-encoded bytes from the HPKE public key
+        let public_key_bytes = self.public_key.to_bytes();
+
+        // 2. Parse these bytes into a p256::PublicKey for validation and type safety
+        let p256_pk = PublicKey::from_sec1_bytes(&public_key_bytes)
+            .map_err(|_| KeyError::InvalidFormat("invalid SEC1 public key point".to_string()))?;
+
+        // 3. Use the EncodePublicKey trait to generate the DER-encoded SPKI
+        let spki_doc = p256_pk
+            .to_public_key_der()
+            .map_err(|_| KeyError::InvalidFormat("SPKI DER encoding failed".to_string()))?;
+
+        // 4. Encode the DER bytes as base64
+        Ok(base64::engine::general_purpose::STANDARD.encode(spki_doc.as_bytes()))
+    }
+
+    /// Decrypts an HPKE-encrypted authorization key from Privy's authentication response.
+    ///
+    /// # HPKE Decryption Process
+    ///
+    /// This method implements the complete HPKE receiver workflow according to RFC 9180:
+    ///
+    /// 1. **Input Validation**: Decode base64 encapsulated key and ciphertext
+    /// 2. **Key Deserialization**: Parse the encapsulated key into P-256 point
+    /// 3. **HPKE Setup**: Derive shared secret using DHKEM(P-256, HKDF-SHA256)
+    /// 4. **Context Derivation**: Create AEAD context with HKDF-SHA256
+    /// 5. **Authenticated Decryption**: Decrypt using `ChaCha20Poly1305`
+    /// 6. **Key Parsing**: Parse decrypted PKCS#8 DER private key
+    ///
+    /// # Arguments
+    ///
+    /// * `encapsulated_key` - Base64-encoded HPKE encapsulated key (65 bytes decoded)
+    ///   - This is Privy's ephemeral P-256 public key used for key agreement
+    ///   - Format: Uncompressed point (0x04 + 32-byte X + 32-byte Y)
+    ///
+    /// * `ciphertext` - Base64-encoded HPKE ciphertext containing encrypted authorization key
+    ///   - Contains the encrypted PKCS#8 DER private key
+    ///   - Protected by `ChaCha20Poly1305` authenticated encryption
+    ///
+    /// # Return Value
+    ///
+    /// Returns a `SecretKey<p256::NistP256>` ready for ECDSA signing operations.
+    /// The key can be used directly with `p256::ecdsa::SigningKey` for wallet signing.
+    ///
+    /// # Errors
+    ///
+    /// Returns `KeyError` variants for different failure modes:
+    /// - `InvalidFormat`: Malformed base64, invalid key points, or bad DER
+    /// - `HpkeDecryption`: HPKE setup failure, authentication failure, or decryption failure
+    ///
+    /// # Example Usage
+    ///
+    /// ```rust,no_run
+    /// use privy_rust::PrivyHpke;
+    /// use privy_api::types::WithEncryptionEncryptedAuthorizationKey;
+    ///
+    /// # async fn example(encrypted_authorization_key: WithEncryptionEncryptedAuthorizationKey) -> Result<(), Box<dyn std::error::Error>> {
+    /// let hpke = PrivyHpke::new();
+    ///
+    /// let auth_key = hpke.decrypt(
+    ///     &encrypted_authorization_key.encapsulated_key,
+    ///     &encrypted_authorization_key.ciphertext
+    /// )?;
+    ///
+    /// // auth_key can now be used for signing wallet transactions
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn decrypt(
+        self,
+        encapsulated_key: &str,
+        ciphertext: &str,
+    ) -> Result<SecretKey<p256::NistP256>, KeyError> {
+        let encapped_key_bytes = base64::engine::general_purpose::STANDARD
+            .decode(encapsulated_key)
+            .map_err(|_| KeyError::InvalidFormat("base64 encapsulated key".to_string()))?;
+
+        let ciphertext_bytes = base64::engine::general_purpose::STANDARD
+            .decode(ciphertext)
+            .map_err(|_| KeyError::InvalidFormat("base64 ciphertext".to_string()))?;
+
+        tracing::debug!(
+            "Deserializing encapsulated key len {}: {:?}",
+            encapped_key_bytes.len(),
+            encapped_key_bytes
+        );
+
+        let encapped_key = <DhP256HkdfSha256 as Kem>::EncappedKey::from_bytes(&encapped_key_bytes)
+            .map_err(|e| {
+                tracing::error!("Failed to deserialize encapsulated key: {e:?}");
+                KeyError::InvalidFormat("encapsulated key".to_string())
+            })?;
+
+        // Set up HPKE context for decryption
+        let mut context = hpke::setup_receiver::<ChaCha20Poly1305, HkdfSha256, DhP256HkdfSha256>(
+            &OpModeR::Base,
+            &self.private_key,
+            &encapped_key,
+            &[],
+        )
+        .map_err(|e| {
+            tracing::error!("HPKE setup failed: {:?}", e);
+            KeyError::HpkeDecryption(format!("HPKE setup failed: {e:?}"))
+        })?;
+
+        // Decrypt the authorization key using the ciphertext
+        let decrypted_key_bytes = context.open(&ciphertext_bytes, &[]).map_err(|e| {
+            tracing::error!("HPKE decryption failed: {:?}", e);
+            KeyError::HpkeDecryption(format!("HPKE decryption failed: {e:?}"))
+        })?;
+
+        // Parse the decrypted bytes as a UTF-8 base64 DER string, then parse as a private key
+        let key_b64 = String::from_utf8(decrypted_key_bytes)
+            .map_err(|_| KeyError::InvalidFormat("decrypted key is not valid UTF-8".to_string()))?;
+
+        tracing::debug!("Decrypted authorization key (base64 DER): {}", key_b64);
+
+        // Decode the base64 to get DER bytes
+        let der_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&key_b64)
+            .map_err(|_| {
+                KeyError::InvalidFormat("decrypted key is not valid base64".to_string())
+            })?;
+
+        // Parse as PKCS#8 DER format (which is what the output format appears to be)
+        SecretKey::<p256::NistP256>::from_pkcs8_der(&der_bytes).map_err(|e| {
+            tracing::error!("Failed to parse decrypted PKCS#8 DER key: {:?}", e);
+            KeyError::InvalidFormat("decrypted PKCS#8 DER key".to_string())
+        })
+    }
+}
+
+impl Default for PrivyHpke {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spki::DecodePublicKey;
+    use test_case::test_case;
+
+    #[test_case(0, "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECT+o7IjvJ+4MjHTU51k5HLoXT9WKzjJKbqkGA3bcvx+ESEbM/wtxRDsptOMcsP+Vn60KdYOjIyLAU/P96CB2lA==" ; "zero")]
+    #[test_case(1, "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5C1LvDxhkHINqB7lRM47O+sUIKTs/2YiPoNOQaRH2tnkhUjRC1x+g9yo0UZr/HzdJKNMAkSXRovCzovSr0jL3A==" ; "one")]
+    #[test_case(10, "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECh6n0GOhDIloBuKZWx2/tPG3rX6oNuQdzH666gAYINFrZcC+GB/zICKGq+f7iXeobumsQiz38X8KKmOQoYkryA==" ; "ten")]
+    fn test_generate_key(seed: u64, expected: &str) {
+        let hpke = super::PrivyHpke::new_with_seed(seed);
+        let public_key = hpke.public_key().unwrap();
+        assert_eq!(public_key, expected);
+    }
+
+    #[test]
+    fn test_spki_round_trip() {
+        // Generate a fresh key pair for the test using a deterministic seed
+        let hpke = PrivyHpke::new_with_seed(42);
+
+        // Generate SPKI using our new library-based method
+        let spki_b64 = hpke.public_key().unwrap();
+        let spki_der = base64::engine::general_purpose::STANDARD
+            .decode(&spki_b64)
+            .unwrap();
+
+        // Use the DecodePublicKey trait to parse the DER back into a key
+        let decoded_pk = PublicKey::from_public_key_der(&spki_der).unwrap();
+
+        // Extract the original key bytes for comparison
+        let original_pk_bytes = hpke.public_key.to_bytes();
+        let original_pk = PublicKey::from_sec1_bytes(&original_pk_bytes).unwrap();
+
+        // Assert that the original key and the decoded key are identical
+        assert_eq!(original_pk, decoded_pk);
+    }
+
+    #[test]
+    fn test_spki_structure_correctness() {
+        let hpke = PrivyHpke::new_with_seed(1337);
+        let spki_b64 = hpke.public_key().unwrap();
+        let spki_der = base64::engine::general_purpose::STANDARD
+            .decode(&spki_b64)
+            .unwrap();
+
+        // Verify SPKI structure basics
+        assert_eq!(spki_der.len(), 91, "SPKI should be exactly 91 bytes");
+
+        // Verify it starts with SEQUENCE tag and correct length
+        assert_eq!(spki_der[0], 0x30, "Should start with SEQUENCE tag");
+        assert_eq!(
+            spki_der[1], 0x59,
+            "SEQUENCE should have 89 bytes of content"
+        );
+
+        // Verify we can successfully parse it back
+        let parsed_key = PublicKey::from_public_key_der(&spki_der).unwrap();
+
+        // Verify the parsed key matches the original
+        let original_pk_bytes = hpke.public_key.to_bytes();
+        let original_pk = PublicKey::from_sec1_bytes(&original_pk_bytes).unwrap();
+        assert_eq!(original_pk, parsed_key);
+    }
+
+    #[test]
+    fn test_spki_base64_format() {
+        let hpke = PrivyHpke::new_with_seed(999);
+        let spki_b64 = hpke.public_key().unwrap();
+
+        // Verify it's valid base64
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&spki_b64)
+            .expect("Should be valid base64");
+
+        // Verify the decoded length is correct for P-256 SPKI
+        assert_eq!(decoded.len(), 91);
+
+        // Verify round-trip through base64
+        let re_encoded = base64::engine::general_purpose::STANDARD.encode(&decoded);
+        assert_eq!(spki_b64, re_encoded);
+    }
+
+    #[test]
+    fn test_error_handling_invalid_key() {
+        // This test ensures our error handling works correctly
+        // We can't easily create an invalid HPKE key, but we can test the p256 parsing path
+        use p256::PublicKey;
+
+        // Test with invalid SEC1 bytes (wrong length)
+        let invalid_bytes = vec![0x04; 32]; // Too short
+        let result = PublicKey::from_sec1_bytes(&invalid_bytes);
+        assert!(result.is_err(), "Should reject invalid SEC1 bytes");
+
+        // Test with invalid SEC1 bytes (wrong format)
+        let invalid_bytes = vec![0x02; 65]; // Wrong format indicator
+        let result = PublicKey::from_sec1_bytes(&invalid_bytes);
+        assert!(result.is_err(), "Should reject invalid format indicator");
+    }
+}


### PR DESCRIPTION
Main impl is in the privy_hpke file. Tried to document everything I picked up while implementing. Rust code since it is so type heavy is usually blindingly obvious as to what is happening so this is written with enough detail to be a reference impl for other SDKs. Now the auth context works with a few different sources:

- path to private key on disk
- private key directly
- jwt auth
- manual signature

Next up is libninja, handling caching properly based on the expiry date and the middleware to inject the signature automatically

```rust
let mut ctx = AuthorizationContext::new();
ctx.push(PrivateKeyFromFile("private_key.pem".into()));
ctx.push(JwtUser(client.clone(), token));
ctx.push(PrivateKey(key));
ctx.push(Signature);

// Sign the canonical request data (UTF-8 bytes)
let signature = ctx
    .sign(canonical_data.as_bytes())
    .map_ok(|s| {
        let der_bytes = s.to_der();
        STANDARD.encode(&der_bytes)
    })
    .try_collect::<Vec<_>>()
    .await?
    .join(",");
```
