### PR TITLE
replace time caching key with central jwtexchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,6 +1693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "lru"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe949189f46fabb938b3a9a0be30fdd93fd8a09260da863399a8cf3db756ec8"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,6 +2092,7 @@ dependencies = [
  "heck",
  "hex",
  "hpke",
+ "lru",
  "openapiv3",
  "p256",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ der = { version = "0.7", features = ["std", "alloc"] }
 const-oid = { version = "0.10.1", features = ["db"] }
 regress = "0.10.4"
 uuid = { version = "1.0", features = ["serde"] }
+lru = "0.16.1"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/src/jwt_exchange.rs
+++ b/src/jwt_exchange.rs
@@ -1,0 +1,119 @@
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+    time::{Duration, SystemTime},
+};
+
+use p256::{NistP256, elliptic_curve::SecretKey};
+
+use crate::{JwtUser, KeyError, PrivyHpke, generated::types::AuthenticateBody};
+
+const EXPIRY_BUFFER: Duration = Duration::from_secs(60);
+
+/// This needs interior mutability so that we don't have to lock the cache for the
+/// entire duration of the network request. Otherwise, in a multi-threaded context,
+/// you would only be able to sign a single signature at a time.
+#[derive(Debug, Clone)]
+pub struct JwtExchange(Arc<Mutex<lru::LruCache<String, (SystemTime, SecretKey<NistP256>)>>>);
+
+impl JwtExchange {
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        JwtExchange(Arc::new(Mutex::new(lru::LruCache::new(capacity))))
+    }
+
+    pub async fn exchange_jwt_for_authorization_key(
+        &self,
+        jwt_user: &JwtUser,
+    ) -> Result<SecretKey<NistP256>, KeyError> {
+        let client = &jwt_user.0;
+        let jwt = &jwt_user.1;
+
+        {
+            let mut cache = self.0.lock().expect("lock poisoned");
+            let expired = if let Some((expiry, key)) = cache.get(jwt) {
+                let buffer = *expiry - EXPIRY_BUFFER;
+                if buffer > SystemTime::now() {
+                    return Ok(key.clone());
+                }
+                true
+            } else {
+                false
+            };
+
+            if expired {
+                // if it was expired, demote it so it is evicted ASAP
+                // it costs the same to check if it exists so just mark it unconditionally
+                cache.demote(jwt);
+            }
+        }
+
+        tracing::debug!("Starting HPKE JWT exchange for user JWT: {}", jwt);
+
+        // Get the HPKE manager and format the public key for the API request
+        let hpke_manager = PrivyHpke::new();
+        let public_key_b64 = hpke_manager.public_key().map_err(|e| {
+            tracing::error!("Failed to format HPKE public key: {:?}", e);
+            KeyError::Unknown
+        })?;
+
+        tracing::debug!(
+            "Generated HPKE public key for authentication request {}",
+            public_key_b64
+        );
+
+        // Build the authentication request with encryption parameters
+        let body = AuthenticateBody {
+            user_jwt: jwt.clone(),
+            encryption_type: Some(crate::generated::types::AuthenticateBodyEncryptionType::Hpke),
+            recipient_public_key: Some(public_key_b64),
+        };
+
+        // Send the authentication request
+        let auth = match client.wallets().authenticate_with_jwt(&body).await {
+            Ok(r) => r.into_inner(),
+            Err(crate::generated::Error::UnexpectedResponse(response)) => {
+                tracing::error!("Unexpected API response: {:?}", response.text().await);
+                return Err(KeyError::Unknown);
+            }
+            Err(e) => {
+                tracing::error!("API request failed: {:?}", e);
+                return Err(KeyError::Unknown);
+            }
+        };
+
+        // Process the response based on encryption type
+        let (key, expiry) = match auth {
+            crate::generated::types::AuthenticateResponse::WithEncryption {
+                encrypted_authorization_key,
+                expires_at,
+                ..
+            } => {
+                tracing::debug!("Received encrypted authorization key, starting HPKE decryption");
+
+                let key = hpke_manager
+                    .decrypt(
+                        &encrypted_authorization_key.encapsulated_key,
+                        &encrypted_authorization_key.ciphertext,
+                    )
+                    .map_err(|e| {
+                        tracing::error!("HPKE decryption failed: {:?}", e);
+                        KeyError::HpkeDecryption(format!("{e:?}"))
+                    })?;
+                let expiry = SystemTime::UNIX_EPOCH + Duration::from_secs_f64(expires_at);
+                (key, expiry)
+            }
+            crate::generated::types::AuthenticateResponse::WithoutEncryption { .. } => {
+                tracing::warn!("Received unencrypted authorization key (fallback mode)");
+                unimplemented!()
+            }
+        };
+
+        {
+            let mut cache = self.0.lock().expect("lock poisoned");
+            cache.push(jwt.clone(), (expiry, key.clone()));
+        }
+
+        tracing::info!("Successfully obtained and parsed authorization key");
+        Ok(key)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod generated {
 pub mod subclients;
 
 pub(crate) mod errors;
+pub(crate) mod jwt_exchange;
 pub(crate) mod keys;
 pub(crate) mod utils;
 

--- a/src/subclients.rs
+++ b/src/subclients.rs
@@ -4,8 +4,10 @@
 //! as well as some manual overrides for things that need the authctx,
 //! following the stainless spec.
 
-use crate::generated::types::{Policy, UpdatePolicyBody, UpdatePolicyPolicyId};
-use crate::{AuthorizationContext, generate_authorization_signatures};
+use crate::{
+    AuthorizationContext, generate_authorization_signatures,
+    generated::types::{Policy, UpdatePolicyBody, UpdatePolicyPolicyId},
+};
 
 include!(concat!(env!("OUT_DIR"), "/subclients.rs"));
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -181,10 +181,12 @@ mod tests {
 
     use super::*;
     use crate::{
-        AuthorizationContext, IntoKey, PrivateKey, PrivateKeyFromFile, PrivyClient,
+        AuthorizationContext, IntoKey, PrivateKey, PrivateKeyFromFile,
         generated::types::{OwnerInput, PublicKeyOwner, UpdateWalletBody},
         get_auth_header,
     };
+
+    const TEST_PRIVATE_KEY_PEM: &str = include_str!("../tests/test_private_key.pem");
 
     #[tokio::test]
     async fn test_build_canonical_request() {
@@ -608,19 +610,6 @@ mod tests {
 
         // NaN should serialize to null in serde_json, so this should actually succeed
         assert!(result.is_ok(), "serde_json handles NaN gracefully");
-    }
-
-    // Integration tests with staging environment
-    #[tokio::test]
-    #[ignore] // Only run when STAGING_* env vars are set
-    async fn test_client_creation_staging() {
-        let (app_id, app_secret, url) = get_staging_env();
-
-        let result = PrivyClient::new_with_url(app_id, app_secret, &url);
-        assert!(
-            result.is_ok(),
-            "Should successfully create client with staging credentials"
-        );
     }
 
     // Test auth header generation


### PR DESCRIPTION
Usage remains the same. The JwtUser now calls a crate-scoped function on the client which centralizes the cache.

This differs slightly from node in that there is not a client-global copy of the Hpke service. The `PrivyHpke` struct is designed such that each operation creates and destroys a new instance and by extension keypair. This is so that the ephemeral private key is destroyed as soon as it decrypts the public key and used for exactly one operation.