### PR TITLE
add e2e tests for wallet service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ env:
   PRIVY_TEST_APP_SECRET: ${{ secrets.PRIVY_TEST_APP_SECRET }}
   PRIVY_TEST_JWT_PRIVATE_KEY: ${{ secrets.PRIVY_TEST_JWT_PRIVATE_KEY }}
   PRIVY_TEST_URL: ${{ secrets.PRIVY_TEST_URL }}
+  # staging authorization flow is very flaky. we'll remove this eventually
+  MARK_FLAKY_TESTS_RETRIES: 20
 
 jobs:
   test:

--- a/.mise.toml
+++ b/.mise.toml
@@ -16,8 +16,6 @@ _.file = ['.env', '.env.local']
 # You can set these values here, or in a .env.local file that mise will load.
 # PRIVY_APP_ID = ""
 # PRIVY_APP_SECRET = ""
-# PRIVY_WALLET_ID = ""
-# PRIVY_PUBLIC_KEY = ""
 
 [tasks.pull-openapi]
 description = "Pull the latest OpenAPI spec from the Privy API repo and apply our overlay"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "agave-feature-set"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c12c927bcda6aa2b42a1b586cde001725c557c181cf1be7d270821a9b160630e"
+dependencies = [
+ "ahash",
+ "solana-epoch-schedule",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher",
+ "solana-svm-feature-set",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -87,6 +129,48 @@ name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
+name = "async-compression"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -140,16 +224,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
+name = "bincode"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -161,10 +262,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bv"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8834bb1d8ee5dc048ee3124f2c7c1afcc6bc9aed03f11e9dfd8c69470a5db340"
+dependencies = [
+ "feature-probe",
+ "serde",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -179,6 +366,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -187,6 +376,12 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -239,10 +434,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
+]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+
+[[package]]
+name = "console"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "core-foundation"
@@ -267,6 +512,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -310,9 +564,12 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
+ "rand_core 0.6.4",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -323,7 +580,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -347,6 +604,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivation-path"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,7 +629,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -396,6 +659,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek-bip32"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b49a684b133c4980d7ee783936af771516011c8cd15f429dbda77245e282f03"
+dependencies = [
+ "derivation-path",
+ "ed25519-dalek",
+ "hmac",
+ "sha2",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +721,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -448,6 +760,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "feature-probe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +786,40 @@ name = "find-msvc-tools"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+
+[[package]]
+name = "five8"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75b8549488b4715defcb0d8a8a1c1c76a80661b5fa106b4ca0e7fce59d7d875"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_const"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26dec3da8bc3ef08f2c04f61eab298c3ab334523e55f076354d6d6f613799a7b"
+dependencies = [
+ "five8_core",
+]
+
+[[package]]
+name = "five8_core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2551bf44bc5f776c15044b9b94153a00198be06743e262afaaa61f11ac7523a5"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -561,7 +913,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -625,9 +977,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.3+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -677,6 +1031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "hpke"
-version = "0.13.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
+checksum = "4917627a14198c3603282c5158b815ad5534795451d3c074b53cf3cee0960b11"
 dependencies = [
  "aead",
  "aes-gcm",
@@ -731,7 +1094,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "p256",
- "rand_core 0.9.3",
+ "rand_core 0.6.4",
  "sha2",
  "subtle",
  "x25519-dalek",
@@ -801,6 +1164,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +1202,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -829,12 +1210,16 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -980,6 +1365,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,7 +1392,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -1006,10 +1404,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1019,6 +1437,21 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpc-core"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
+dependencies = [
+ "futures",
+ "futures-executor",
+ "futures-util",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -1034,6 +1467,29 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1086,6 +1542,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mark-flaky-tests"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "586c4a7c95a05351b04ebbe4f60edc53c3bb611651b1bf0be54a9575a95b4930"
+dependencies = [
+ "futures",
+ "mark-flaky-tests-macro",
+]
+
+[[package]]
+name = "mark-flaky-tests-macro"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078b1ffd16b299642ebc515a520c3793f6fe0db38c2e6a2abf686db22e58ab84"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1584,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1169,6 +1663,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1184,6 +1689,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1224,7 +1751,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1241,7 +1768,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1295,6 +1822,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1374,6 +1910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,7 +1946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1437,6 +1979,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
+ "bincode",
  "chrono",
  "der",
  "dotenv",
@@ -1446,34 +1989,80 @@ dependencies = [
  "hpke",
  "jsonwebtoken",
  "lru",
+ "mark-flaky-tests",
  "openapiv3",
  "p256",
  "prettyplease",
  "privy-openapi",
  "proc-macro2",
  "progenitor",
- "progenitor-client",
  "quote",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "regress",
  "reqwest",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
- "serde_path_to_error",
  "serde_yaml",
  "sha2",
+ "solana-rpc-client",
+ "solana-sdk",
+ "solana-system-interface",
+ "solana-transaction",
  "spki",
- "syn",
+ "syn 2.0.106",
  "tempfile",
  "test-case",
- "thiserror",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
  "uuid",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+dependencies = [
+ "toml_edit 0.23.5",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1527,8 +2116,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "syn",
- "thiserror",
+ "syn 2.0.106",
+ "thiserror 2.0.16",
  "typify",
  "unicode-ident",
 ]
@@ -1548,7 +2137,71 @@ dependencies = [
  "serde_json",
  "serde_tokenstream",
  "serde_yaml",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.16",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1568,12 +2221,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1610,7 +2284,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
 ]
 
 [[package]]
@@ -1654,13 +2328,15 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1668,32 +2344,50 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
 ]
 
 [[package]]
@@ -1727,6 +2421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,7 +2441,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1749,12 +2449,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
+ "once_cell",
+ "ring",
  "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1763,7 +2468,19 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
+ "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1816,7 +2533,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1845,7 +2562,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1873,32 +2590,51 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.224"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
 dependencies = [
  "serde_core",
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.224"
+name = "serde-big-array"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.227"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.224"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
+checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1909,7 +2645,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1936,17 +2672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_tokenstream"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,7 +2680,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1992,6 +2717,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -2036,9 +2771,15 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 2.0.16",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -2063,6 +2804,1125 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-account"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f885ce7f937871ecb56aadbeaaec963b234a580b7d6ebbdb8fa4249a36f92433"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-instruction-error",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-sysvar",
+]
+
+[[package]]
+name = "solana-account-decoder-client-types"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45ff8e59c3ecec64d86d8dbace1e6fa0c9fd9f09761a7124eeae138a9278aa1c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account",
+ "solana-pubkey",
+ "zstd",
+]
+
+[[package]]
+name = "solana-account-info"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f4691b69b172c687d218dd2f1f23fc7ea5e9aa79df9ac26dab3d8dd829ce48"
+dependencies = [
+ "bincode",
+ "serde",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-address"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7a457086457ea9db9a5199d719dc8734dc2d0342fad0d8f77633c31eb62f19"
+dependencies = [
+ "borsh",
+ "bytemuck",
+ "bytemuck_derive",
+ "curve25519-dalek",
+ "five8",
+ "five8_const",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "solana-atomic-u64",
+ "solana-define-syscall",
+ "solana-program-error",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-address-lookup-table-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2f56cac5e70517a2f27d05e5100b20de7182473ffd0035b23ea273307905987"
+dependencies = [
+ "solana-clock",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-slot-hashes",
+]
+
+[[package]]
+name = "solana-atomic-u64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a933ff1e50aff72d02173cfcd7511bd8540b027ee720b75f353f594f834216d0"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "solana-big-mod-exp"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "solana-define-syscall",
+]
+
+[[package]]
+name = "solana-blake3-hasher"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffa2e3bdac3339c6d0423275e45dafc5ac25f4d43bf344d026a3cc9a85e244a6"
+dependencies = [
+ "blake3",
+ "solana-define-syscall",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-borsh"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc402b16657abbfa9991cd5cbfac5a11d809f7e7d28d3bb291baeb088b39060e"
+dependencies = [
+ "borsh",
+]
+
+[[package]]
+name = "solana-clock"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb62e9381182459a4520b5fe7fb22d423cae736239a6427fc398a88743d0ed59"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-commitment-config"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa5933a62dadb7d3ed35e6329de5cebb0678acc8f9cfdf413269084eeccc63f"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-cpi"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16238feb63d1cbdf915fb287f29ef7a7ebf81469bd6214f8b72a53866b593f8f"
+dependencies = [
+ "solana-account-info",
+ "solana-define-syscall",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-stable-layout",
+]
+
+[[package]]
+name = "solana-define-syscall"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
+
+[[package]]
+name = "solana-derivation-path"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff71743072690fdbdfcdc37700ae1cb77485aaad49019473a81aee099b1e0b8c"
+dependencies = [
+ "derivation-path",
+ "qstring",
+ "uriparse",
+]
+
+[[package]]
+name = "solana-epoch-info"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6b69bd71386f61344f2bcf0f527f5fd6dd3b22add5880e2e1bf1dd1fa8059"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-epoch-rewards"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b319a4ed70390af911090c020571f0ff1f4ec432522d05ab89f5c08080381995"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-epoch-rewards-hasher"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e507099d0c2c5d7870c9b1848281ea67bbeee80d171ca85003ee5767994c9c38"
+dependencies = [
+ "siphasher",
+ "solana-hash",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-epoch-schedule"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e5481e72cc4d52c169db73e4c0cd16de8bc943078aac587ec4817a75cc6388f"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-epoch-stake"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc6693d0ea833b880514b9b88d95afb80b42762dca98b0712465d1fcbbcb89e"
+dependencies = [
+ "solana-define-syscall",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-example-mocks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978855d164845c1b0235d4b4d101cadc55373fffaf0b5b6cfa2194d25b2ed658"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-address-lookup-table-interface",
+ "solana-clock",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keccak-hasher",
+ "solana-message",
+ "solana-nonce",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "solana-feature-gate-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347ab62e6d47a82e340c865133795b394feea7c2b2771d293f57691c6544c3f"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-fee-calculator"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a73cc03ca4bed871ca174558108835f8323e85917bb38b9c81c7af2ab853efe"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-fee-structure"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2abdb1223eea8ec64136f39cb1ffcf257e00f915c957c35c0dd9e3f4e700b0"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-hard-forks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abacc4b66ce471f135f48f22facf75cbbb0f8a252fbe2c1e0aa59d5b203f519"
+
+[[package]]
+name = "solana-hash"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a063723b9e84c14d8c0d2cdf0268207dc7adecf546e31251f9e07c7b00b566c"
+dependencies = [
+ "borsh",
+ "bytemuck",
+ "bytemuck_derive",
+ "five8",
+ "serde",
+ "serde_derive",
+ "solana-atomic-u64",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-inflation"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92f37a14e7c660628752833250dd3dcd8e95309876aee751d7f8769a27947c6"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-instruction"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df4e8fcba01d7efa647ed20a081c234475df5e11a93acb4393cc2c9a7b99bab"
+dependencies = [
+ "bincode",
+ "borsh",
+ "serde",
+ "serde_derive",
+ "solana-define-syscall",
+ "solana-instruction-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-instruction-error"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f0d483b8ae387178d9210e0575b666b05cdd4bd0f2f188128249f6e454d39d"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-instructions-sysvar"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
+dependencies = [
+ "bitflags",
+ "solana-account-info",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-program-error",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-keccak-hasher"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57eebd3012946913c8c1b8b43cdf8a6249edb09c0b6be3604ae910332a3acd97"
+dependencies = [
+ "sha3",
+ "solana-define-syscall",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-keypair"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "952ed9074c12edd2060cb09c2a8c664303f4ab7f7056a407ac37dd1da7bdaa3e"
+dependencies = [
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
+ "five8",
+ "rand 0.8.5",
+ "solana-derivation-path",
+ "solana-pubkey",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-signature",
+ "solana-signer",
+]
+
+[[package]]
+name = "solana-last-restart-slot"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcda154ec827f5fc1e4da0af3417951b7e9b8157540f81f936c4a8b1156134d0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-message"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85666605c9fd727f865ed381665db0a8fc29f984a030ecc1e40f43bfb2541623"
+dependencies = [
+ "bincode",
+ "blake3",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-address",
+ "solana-hash",
+ "solana-instruction",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-msg"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "264275c556ea7e22b9d3f87d56305546a38d4eee8ec884f3b126236cb7dcbbb4"
+dependencies = [
+ "solana-define-syscall",
+]
+
+[[package]]
+name = "solana-native-token"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8dd4c280dca9d046139eb5b7a5ac9ad10403fbd64964c7d7571214950d758f"
+
+[[package]]
+name = "solana-nonce"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abbdc6c8caf1c08db9f36a50967539d0f72b9f1d4aea04fec5430f532e5afadc"
+dependencies = [
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-pubkey",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-offchain-message"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e2a1141a673f72a05cf406b99e4b2b8a457792b7c01afa07b3f00d4e2de393"
+dependencies = [
+ "num_enum",
+ "solana-hash",
+ "solana-packet",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sha256-hasher",
+ "solana-signature",
+ "solana-signer",
+]
+
+[[package]]
+name = "solana-packet"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "solana-presigner"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f704eaf825be3180832445b9e4983b875340696e8e7239bf2d535b0f86c14a2"
+dependencies = [
+ "solana-pubkey",
+ "solana-signature",
+ "solana-signer",
+]
+
+[[package]]
+name = "solana-program"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91b12305dd81045d705f427acd0435a2e46444b65367d7179d7bdcfc3bc5f5eb"
+dependencies = [
+ "memoffset",
+ "solana-account-info",
+ "solana-big-mod-exp",
+ "solana-blake3-hasher",
+ "solana-borsh",
+ "solana-clock",
+ "solana-cpi",
+ "solana-define-syscall",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-epoch-stake",
+ "solana-example-mocks",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-instructions-sysvar",
+ "solana-keccak-hasher",
+ "solana-last-restart-slot",
+ "solana-msg",
+ "solana-native-token",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-program-option",
+ "solana-program-pack",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-secp256k1-recover",
+ "solana-serde-varint",
+ "solana-serialize-utils",
+ "solana-sha256-hasher",
+ "solana-short-vec",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-stable-layout",
+ "solana-sysvar",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-program-entrypoint"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6557cf5b5e91745d1667447438a1baa7823c6086e4ece67f8e6ebfa7a8f72660"
+dependencies = [
+ "solana-account-info",
+ "solana-define-syscall",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-program-error"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
+dependencies = [
+ "borsh",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-program-memory"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10e5660c60749c7bfb30b447542529758e4dbcecd31b1e8af1fdc92e2bdde90a"
+dependencies = [
+ "solana-define-syscall",
+]
+
+[[package]]
+name = "solana-program-option"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7b4ddb464f274deb4a497712664c3b612e3f5f82471d4e47710fc4ab1c3095"
+
+[[package]]
+name = "solana-program-pack"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c169359de21f6034a63ebf96d6b380980307df17a8d371344ff04a883ec4e9d0"
+dependencies = [
+ "solana-program-error",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
+dependencies = [
+ "rand 0.8.5",
+ "solana-address",
+]
+
+[[package]]
+name = "solana-rent"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b702d8c43711e3c8a9284a4f1bbc6a3de2553deb25b0c8142f9a44ef0ce5ddc1"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-reward-info"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "solana-rpc-client"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c53ce9b77ad156cd56ed10ea7092cfce0f648f6b213528bd6a8bc7549dc01ea"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bincode",
+ "bs58",
+ "futures",
+ "indicatif",
+ "log",
+ "reqwest",
+ "reqwest-middleware",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account",
+ "solana-account-decoder-client-types",
+ "solana-clock",
+ "solana-commitment-config",
+ "solana-epoch-info",
+ "solana-epoch-schedule",
+ "solana-feature-gate-interface",
+ "solana-hash",
+ "solana-instruction",
+ "solana-message",
+ "solana-pubkey",
+ "solana-rpc-client-api",
+ "solana-signature",
+ "solana-transaction",
+ "solana-transaction-error",
+ "solana-transaction-status-client-types",
+ "solana-version",
+ "solana-vote-interface",
+ "tokio",
+]
+
+[[package]]
+name = "solana-rpc-client-api"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c742cd5a418c2288fffeb16190bdeba58f49f0a5ab7fa762af6a687b7664405"
+dependencies = [
+ "anyhow",
+ "jsonrpc-core",
+ "reqwest",
+ "reqwest-middleware",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account-decoder-client-types",
+ "solana-clock",
+ "solana-rpc-client-types",
+ "solana-signer",
+ "solana-transaction-error",
+ "solana-transaction-status-client-types",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "solana-rpc-client-types"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8820478ef4b059ae2dc6e10e7d047230486225f8e986f685ab8d9d0d23eb137"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account",
+ "solana-account-decoder-client-types",
+ "solana-clock",
+ "solana-commitment-config",
+ "solana-fee-calculator",
+ "solana-inflation",
+ "solana-pubkey",
+ "solana-transaction-error",
+ "solana-transaction-status-client-types",
+ "solana-version",
+ "spl-generic-token",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "solana-sanitize"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
+
+[[package]]
+name = "solana-sbpf"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f224d906c14efc7ed7f42bc5fe9588f3f09db8cabe7f6023adda62a69678e1a"
+dependencies = [
+ "byteorder",
+ "combine",
+ "hash32",
+ "log",
+ "rustc-demangle",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "solana-sdk"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f03df7969f5e723ad31b6c9eadccc209037ac4caa34d8dc259316b05c11e82b"
+dependencies = [
+ "bincode",
+ "bs58",
+ "serde",
+ "solana-account",
+ "solana-epoch-info",
+ "solana-epoch-rewards-hasher",
+ "solana-fee-structure",
+ "solana-inflation",
+ "solana-keypair",
+ "solana-message",
+ "solana-offchain-message",
+ "solana-presigner",
+ "solana-program",
+ "solana-program-memory",
+ "solana-pubkey",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-seed-derivable",
+ "solana-seed-phrase",
+ "solana-serde",
+ "solana-serde-varint",
+ "solana-short-vec",
+ "solana-shred-version",
+ "solana-signature",
+ "solana-signer",
+ "solana-time-utils",
+ "solana-transaction",
+ "solana-transaction-error",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "solana-sdk-ids"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1b6d6aaf60669c592838d382266b173881c65fb1cdec83b37cb8ce7cb89f9ad"
+dependencies = [
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-sdk-macro"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6430000e97083460b71d9fbadc52a2ab2f88f53b3a4c5e58c5ae3640a0e8c00"
+dependencies = [
+ "bs58",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "solana-secp256k1-recover"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394a4470477d66296af5217970a905b1c5569032a7732c367fb69e5666c8607e"
+dependencies = [
+ "k256",
+ "solana-define-syscall",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "solana-seed-derivable"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff7bdb72758e3bec33ed0e2658a920f1f35dfb9ed576b951d20d63cb61ecd95c"
+dependencies = [
+ "solana-derivation-path",
+]
+
+[[package]]
+name = "solana-seed-phrase"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
+dependencies = [
+ "hmac",
+ "pbkdf2",
+ "sha2",
+]
+
+[[package]]
+name = "solana-serde"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709a93cab694c70f40b279d497639788fc2ccbcf9b4aa32273d4b361322c02dd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "solana-serde-varint"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5174c57d5ff3c1995f274d17156964664566e2cde18a07bba1586d35a70d3b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "solana-serialize-utils"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e41dd8feea239516c623a02f0a81c2367f4b604d7965237fed0751aeec33ed"
+dependencies = [
+ "solana-instruction-error",
+ "solana-pubkey",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-sha256-hasher"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b912ba6f71cb202c0c3773ec77bf898fa9fe0c78691a2d6859b3b5b8954719"
+dependencies = [
+ "sha2",
+ "solana-define-syscall",
+ "solana-hash",
+]
+
+[[package]]
+name = "solana-short-vec"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69d029da5428fc1c57f7d49101b2077c61f049d4112cd5fb8456567cc7d2638"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "solana-shred-version"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94953e22ca28fe4541a3447d6baeaf519cc4ddc063253bfa673b721f34c136bb"
+dependencies = [
+ "solana-hard-forks",
+ "solana-hash",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-signature"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb8057cc0e9f7b5e89883d49de6f407df655bb6f3a71d0b7baf9986a2218fd9"
+dependencies = [
+ "ed25519-dalek",
+ "five8",
+ "rand 0.8.5",
+ "serde",
+ "serde-big-array",
+ "serde_derive",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-signer"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bfea97951fee8bae0d6038f39a5efcb6230ecdfe33425ac75196d1a1e3e3235"
+dependencies = [
+ "solana-pubkey",
+ "solana-signature",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-slot-hashes"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a293f952293281443c04f4d96afd9d547721923d596e92b4377ed2360f1746"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-hash",
+ "solana-sdk-ids",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-slot-history"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f914f6b108f5bba14a280b458d023e3621c9973f27f015a4d755b50e88d89e97"
+dependencies = [
+ "bv",
+ "serde",
+ "serde_derive",
+ "solana-sdk-ids",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-stable-layout"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1da74507795b6e8fb60b7c7306c0c36e2c315805d16eaaf479452661234685ac"
+dependencies = [
+ "solana-instruction",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-svm-feature-set"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f90a27275c66047c0ab24af4a5ea7fad1887f58cc6a142b4e60ddd41e46972e"
+
+[[package]]
+name = "solana-system-interface"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1790547bfc3061f1ee68ea9d8dc6c973c02a163697b24263a8e9f2e6d4afa2"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
+ "solana-pubkey",
+]
+
+[[package]]
+name = "solana-sysvar"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63205e68d680bcc315337dec311b616ab32fea0a612db3b883ce4de02e0953f9"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bytemuck",
+ "bytemuck_derive",
+ "lazy_static",
+ "serde",
+ "serde_derive",
+ "solana-account-info",
+ "solana-clock",
+ "solana-define-syscall",
+ "solana-epoch-rewards",
+ "solana-epoch-schedule",
+ "solana-fee-calculator",
+ "solana-hash",
+ "solana-instruction",
+ "solana-last-restart-slot",
+ "solana-program-entrypoint",
+ "solana-program-error",
+ "solana-program-memory",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-sdk-macro",
+ "solana-slot-hashes",
+ "solana-slot-history",
+ "solana-sysvar-id",
+]
+
+[[package]]
+name = "solana-sysvar-id"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5051bc1a16d5d96a96bc33b5b2ec707495c48fe978097bdaba68d3c47987eb32"
+dependencies = [
+ "solana-pubkey",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-time-utils"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced92c60aa76ec4780a9d93f3bd64dfa916e1b998eacc6f1c110f3f444f02c9"
+
+[[package]]
+name = "solana-transaction"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64928e6af3058dcddd6da6680cbe08324b4e071ad73115738235bbaa9e9f72a5"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-address",
+ "solana-hash",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-message",
+ "solana-sanitize",
+ "solana-sdk-ids",
+ "solana-short-vec",
+ "solana-signature",
+ "solana-signer",
+ "solana-transaction-error",
+]
+
+[[package]]
+name = "solana-transaction-context"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239b7583ddb92669855a47e52772e9fa5294d415f6450e55da58e302065e3b39"
+dependencies = [
+ "bincode",
+ "serde",
+ "serde_derive",
+ "solana-account",
+ "solana-instruction",
+ "solana-instructions-sysvar",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sbpf",
+ "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-transaction-error"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4222065402340d7e6aec9dc3e54d22992ddcf923d91edcd815443c2bfca3144a"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "solana-instruction-error",
+ "solana-sanitize",
+]
+
+[[package]]
+name = "solana-transaction-status-client-types"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "481fc38459449fd4dd2ff6cc35dd14dd91e50124522ca36edc682920304e8984"
+dependencies = [
+ "base64 0.22.1",
+ "bincode",
+ "bs58",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "solana-account-decoder-client-types",
+ "solana-commitment-config",
+ "solana-instruction",
+ "solana-message",
+ "solana-pubkey",
+ "solana-reward-info",
+ "solana-signature",
+ "solana-transaction",
+ "solana-transaction-context",
+ "solana-transaction-error",
+ "thiserror 2.0.16",
+]
+
+[[package]]
+name = "solana-version"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b76862cbee612c3a1da487611f1e489e31a740002b15191fdec026501914e942"
+dependencies = [
+ "agave-feature-set",
+ "rand 0.8.5",
+ "semver",
+ "serde",
+ "serde_derive",
+ "solana-sanitize",
+ "solana-serde-varint",
+]
+
+[[package]]
+name = "solana-vote-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66631ddbe889dab5ec663294648cd1df395ec9df7a4476e7b3e095604cfdb539"
+dependencies = [
+ "num-derive",
+ "num-traits",
+ "solana-clock",
+ "solana-hash",
+ "solana-instruction",
+ "solana-instruction-error",
+ "solana-pubkey",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-serialize-utils",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +3930,16 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "spl-generic-token"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233df81b75ab99b42f002b5cdd6e65a7505ffa930624f7096a7580a56765e9cf"
+dependencies = [
+ "bytemuck",
+ "solana-pubkey",
 ]
 
 [[package]]
@@ -2086,6 +3956,16 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
@@ -2097,9 +3977,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2109,25 +3992,25 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2164,7 +4047,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2175,8 +4058,17 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "test-case-core",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -2185,7 +4077,18 @@ version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2196,7 +4099,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2249,6 +4152,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,7 +4194,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2286,6 +4204,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
+dependencies = [
+ "rustls",
  "tokio",
 ]
 
@@ -2301,6 +4229,92 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.2",
+ "toml_parser",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -2327,7 +4341,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2387,7 +4401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2427,8 +4441,8 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "syn",
- "thiserror",
+ "syn 2.0.106",
+ "thiserror 2.0.16",
  "unicode-ident",
 ]
 
@@ -2445,7 +4459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_tokenstream",
- "syn",
+ "syn 2.0.106",
  "typify-impl",
 ]
 
@@ -2456,6 +4470,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2463,6 +4489,15 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
 ]
 
 [[package]]
@@ -2476,6 +4511,16 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
+]
 
 [[package]]
 name = "url"
@@ -2526,6 +4571,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,7 +4622,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -2606,7 +4657,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2644,6 +4695,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,8 +4722,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.2.0",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
@@ -2664,7 +4734,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2675,7 +4745,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2691,6 +4761,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,20 +4791,20 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
  "windows-link 0.2.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2745,18 +4835,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2794,12 +4878,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2812,12 +4890,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2827,12 +4899,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2860,12 +4926,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2875,12 +4935,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2896,12 +4950,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2911,12 +4959,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2931,13 +4973,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
+name = "winnow"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2982,7 +5032,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3003,7 +5053,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3023,7 +5073,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3044,7 +5094,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3077,5 +5127,33 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1077,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hkdf"
@@ -2001,11 +2026,13 @@ dependencies = [
  "rand_chacha 0.3.1",
  "regress",
  "reqwest",
+ "secp256k1",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
  "serde_yaml",
  "sha2",
+ "sha3",
  "solana-rpc-client",
  "solana-sdk",
  "solana-system-interface",
@@ -2554,6 +2581,26 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ members = [".", "crates/privy-openapi"]
 
 [dependencies]
 # dependencies from progenitor
-progenitor-client = "0.11.0"
 reqwest = { version = "0.12", features = ["json"] }
 regress = "0.10.4" # js-compatible regex
 serde = { version = "1.0", features = ["derive"] }
@@ -25,8 +24,8 @@ base64 = "0.21"
 serde_json_canonicalizer = "0.3.1"
 sha2 = "0.10.9"
 hex = "0.4"
-hpke = "0.13.0"
-rand = "0.9.2"
+hpke = "0.12.0"
+rand = "0.8.5"
 spki = { version = "0.7", features = ["std", "alloc"] }
 der = { version = "0.7", features = ["std", "alloc"] }
 
@@ -47,12 +46,17 @@ test-case = "3.3.1"
 tempfile = "3.0"
 
 # used for deterministic key generation under testing
-rand_chacha = "0.9.0"
-hex = "0.4"
-serde_path_to_error = "0.1.17"
+rand_chacha = "0.3.1"
 
 # uuid again here since we don't need feature v4 outside of dev deps
 uuid = { version = "1.18.1", features = ["v4"] }
+
+solana-sdk = "3.0.0"
+solana-rpc-client = "3.0.2"
+solana-system-interface = { version = "2.0.0", features = ["bincode"] }
+bincode = "1.3.3"
+solana-transaction = { version = "3.0.1", features = ["bincode", "serde"] }
+mark-flaky-tests = { version = "1.0.2", features = ["tokio"] }
 
 [[example]]
 doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ base64 = "0.21"
 serde_json_canonicalizer = "0.3.1"
 sha2 = "0.10.9"
 hex = "0.4"
-hpke = "0.12.0"
+hpke = { version = "0.12.0", features = ["std"] }
 rand = "0.8.5"
 spki = { version = "0.7", features = ["std", "alloc"] }
 der = { version = "0.7", features = ["std", "alloc"] }
@@ -57,6 +57,8 @@ solana-system-interface = { version = "2.0.0", features = ["bincode"] }
 bincode = "1.3.3"
 solana-transaction = { version = "3.0.1", features = ["bincode", "serde"] }
 mark-flaky-tests = { version = "1.0.2", features = ["tokio"] }
+secp256k1 = { version = "0.30", features = ["global-context", "rand"] }
+sha3 = "0.10.8"
 
 [[example]]
 doc-scrape-examples = true

--- a/build.rs
+++ b/build.rs
@@ -160,7 +160,8 @@ fn parse_resource_config(name: &str, config: &Value) -> ResourceConfig {
                     _ => continue,
                 };
 
-                let private = method_name_str.starts_with('_');
+                // we still want to allow private methods to be used for advanced use-cases
+                let private = false;
 
                 methods.push(MethodConfig {
                     name: method_name_str.to_string(),

--- a/examples/delete_user.rs
+++ b/examples/delete_user.rs
@@ -32,17 +32,11 @@ async fn main() -> Result<()> {
     let app_id = std::env::var("PRIVY_APP_ID").expect("PRIVY_APP_ID environment variable not set");
     let app_secret =
         std::env::var("PRIVY_APP_SECRET").expect("PRIVY_APP_SECRET environment variable not set");
-    let wallet_id =
-        std::env::var("PRIVY_WALLET_ID").expect("PRIVY_WALLET_ID environment variable not set");
-    let public_key =
-        std::env::var("PRIVY_PUBLIC_KEY").expect("PRIVY_PUBLIC_KEY environment variable not set");
 
     tracing::info!(
-        "initializing privy with app_id: {}, app_secret: {}, wallet_id: {}, public_key: {}",
+        "initializing privy with app_id: {}, app_secret: {}",
         app_id,
-        app_secret,
-        wallet_id,
-        public_key
+        app_secret
     );
 
     let client = PrivyClient::new(app_id, app_secret)?;

--- a/examples/update_wallet.rs
+++ b/examples/update_wallet.rs
@@ -11,7 +11,6 @@
 //! - `PRIVY_APP_ID`: Your Privy app ID
 //! - `PRIVY_APP_SECRET`: Your Privy app secret
 //! - `PRIVY_WALLET_ID`: The wallet ID to update
-//! - `PRIVY_PRIVATE_KEY_PATH`: Path to the private key file for authorization
 //!
 //! ## Usage
 //! ```bash

--- a/examples/wallet_export.rs
+++ b/examples/wallet_export.rs
@@ -21,10 +21,7 @@
 
 use anyhow::Result;
 use hex::ToHex;
-use privy_rs::{
-    AuthorizationContext, JwtUser, PrivateKey, PrivyClient,
-    generated::types::{HpkeEncryption, WalletExportRequestBody},
-};
+use privy_rs::{AuthorizationContext, JwtUser, PrivateKey, PrivyClient};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -49,10 +46,6 @@ async fn main() -> Result<()> {
         wallet_id
     );
 
-    // Generate HPKE key pair for encryption
-    let hpke_keypair = privy_rs::privy_hpke::PrivyHpke::new();
-    let recipient_public_key = hpke_keypair.public_key()?;
-
     tracing::info!("Generated HPKE key pair for encryption");
 
     let private_key = std::fs::read_to_string("private_key.pem")?;
@@ -64,31 +57,13 @@ async fn main() -> Result<()> {
     ctx.push(JwtUser(client.clone(), "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhbGV4QGFybHlvbi5kZXYiLCJpYXQiOjEwMDAwMDAwMDAwMH0.IpNgavH95CFZPjkzQW4eyxMIfJ-O_5cIaDyu_6KRXffykjYDRwxTgFJuYq0F6d8wSXf4de-vzfBRWSKMISM3rJdlhximYINGJB14mJFCD87VMLFbTpHIXcv7hc1AAYMPGhOsRkYfYXuvVopKszMvhupmQYJ1npSvKWNeBniIyOHYv4xebZD8L0RVlPvuEKTXTu-CDfs2rMwvD9g_wiBznS3uMF3v_KPaY6x0sx9zeCSxAH9zvhMMtct_Ad9kuoUncGpRzNhEk6JlVccN2Leb1JzbldxSywyS2AApD05u-GFAgFDN3P39V3qgRTGDuuUfUvKQ9S4rbu5El9Qq1CJTeA".to_string()));
 
     // Export wallet private key (requires authorization signature)
-    let export_response = client
-        .wallets()
-        .export(
-            &wallet_id,
-            &ctx,
-            &WalletExportRequestBody {
-                encryption_type: HpkeEncryption::Hpke,
-                recipient_public_key,
-            },
-        )
-        .await?;
-
-    tracing::info!("Received encrypted wallet export response");
-
-    // Decrypt the exported private key
-    let decrypted_key = hpke_keypair.decrypt(
-        &export_response.encapsulated_key,
-        &export_response.ciphertext,
-    )?;
+    let secret_key = client.wallets().export(&wallet_id, &ctx).await?;
 
     tracing::info!("Successfully decrypted private key");
     tracing::warn!("SECURITY WARNING: Private key exported and decrypted!");
     println!(
         "Decrypted private key (hex): {}",
-        decrypted_key.to_bytes().encode_hex::<String>()
+        secret_key.to_bytes().encode_hex::<String>()
     );
 
     Ok(())

--- a/examples/wallet_rpc.rs
+++ b/examples/wallet_rpc.rs
@@ -19,13 +19,12 @@
 use anyhow::Result;
 use base64::{Engine, engine::general_purpose::STANDARD};
 use privy_rs::{
-    AuthorizationContext, JwtUser, PrivateKey, PrivyClient, PrivySignedApiError,
+    AuthorizationContext, JwtUser, PrivateKey, PrivyApiError, PrivyClient, PrivySignedApiError,
     generated::types::{
         SolanaSignMessageRpcInput, SolanaSignMessageRpcInputMethod,
         SolanaSignMessageRpcInputParams, SolanaSignMessageRpcInputParamsEncoding, WalletRpcBody,
     },
 };
-use progenitor_client::Error;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -78,7 +77,7 @@ async fn main() -> Result<()> {
         .await
     {
         Ok(r) => r,
-        Err(PrivySignedApiError::Api(Error::UnexpectedResponse(resp))) => {
+        Err(PrivySignedApiError::Api(PrivyApiError::UnexpectedResponse(resp))) => {
             tracing::error!("Unexpected response: {:?}", resp.text().await);
             return Err(anyhow::anyhow!("Unexpected response"));
         }

--- a/openapi.json
+++ b/openapi.json
@@ -2789,10 +2789,10 @@
           "recovery_method",
           "verified_at",
           "first_verified_at",
-          "latest_verified_at",
-          "public_key"
+          "latest_verified_at"
         ],
-        "title": "Solana Embedded Wallet"
+        "title": "Solana Embedded Wallet",
+        "//comment": "We removed public key from this list since it is not being returned in some cases"
       },
       "LinkedAccountBitcoinSegwitEmbeddedWallet": {
         "type": "object",

--- a/openapi.overlay.json
+++ b/openapi.overlay.json
@@ -26,6 +26,26 @@
 						"title": "User owner"
 					}
 				]
+			},
+			"LinkedAccountSolanaEmbeddedWallet": {
+				"//comment": "We removed public key from this list since it is not being returned in some cases",
+				"required": [
+					"id",
+					"type",
+					"address",
+					"imported",
+					"delegated",
+					"wallet_index",
+					"chain_id",
+					"chain_type",
+					"wallet_client",
+					"wallet_client_type",
+					"connector_type",
+					"recovery_method",
+					"verified_at",
+					"first_verified_at",
+					"latest_verified_at"
+				]
 			}
 		}
 	},

--- a/src/client.rs
+++ b/src/client.rs
@@ -114,6 +114,7 @@ impl PrivyClient {
         crate::utils::Utils(self.app_id.clone())
     }
 
+    /// Returns the app id for the client
     pub fn app_id(&self) -> &str {
         &self.app_id
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,23 @@ pub enum PrivySignedApiError {
     SignatureGeneration(#[from] SignatureGenerationError),
 }
 
+/// Errors that can appear during wallet export.
+#[derive(Error, Debug)]
+pub enum PrivyExportError {
+    /// An error returned by the Privy API (e.g., 4xx or 5xx HTTP status codes).
+    /// Contains the raw response for further inspection.
+    #[error("API request failed")]
+    Api(#[from] PrivyApiError),
+
+    /// An error occurred during the signing process.
+    #[error("Signature generation failed: {0}")]
+    SignatureGeneration(#[from] SignatureGenerationError),
+
+    /// An error occurred during the decryption process.
+    #[error("Unable to decrypt key: {0}")]
+    Key(#[from] KeyError),
+}
+
 /// Errors related to cryptographic keys and operations.
 #[derive(Error, Debug)]
 pub enum CryptoError {
@@ -54,7 +71,7 @@ pub enum KeyError {
 
     /// Failed to decrypt an HPKE-encrypted payload.
     #[error("HPKE decryption failed: {0}")]
-    HpkeDecryption(String),
+    HpkeDecryption(#[from] hpke::HpkeError),
 
     /// An unknown error occurred.
     #[error(transparent)]

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -511,7 +511,7 @@ impl EthereumService {
     ///     gas_limit: None,
     ///     max_fee_per_gas: None,
     ///     max_priority_fee_per_gas: None,
-    ///     data: None,
+    ///     data: Some("0x".to_string()),
     ///     chain_id: None,
     ///     from: None,
     ///     gas_price: None,

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,0 +1,119 @@
+use base64::Engine;
+use hpke::{
+    Deserializable, OpModeS, Serializable, aead::ChaCha20Poly1305, kdf::HkdfSha256,
+    kem::DhP256HkdfSha256,
+};
+
+use crate::{
+    generated::{
+        Error, ResponseValue,
+        types::{
+            PrivateKeySubmitInput, Wallet, WalletImportInitializationResponse,
+            WalletImportSubmissionRequest, WalletImportSubmissionRequestOwner,
+            WalletImportSubmissionRequestWallet, WalletImportSupportedChains,
+        },
+    },
+    subclients::WalletsClient,
+};
+
+pub struct WalletImport {
+    client: WalletsClient,
+    initialization_response: WalletImportInitializationResponse,
+    address: String,
+    chain_type: WalletImportSupportedChains,
+}
+
+impl WalletImport {
+    pub(crate) fn new(
+        client: WalletsClient,
+        initialization_response: WalletImportInitializationResponse,
+        address: String,
+        chain_type: WalletImportSupportedChains,
+    ) -> Self {
+        Self {
+            client,
+            initialization_response,
+            address,
+            chain_type,
+        }
+    }
+
+    fn encrypt_private_key(
+        &self,
+        private_key_hex: &str,
+    ) -> Result<(String, String), Box<dyn std::error::Error>> {
+        // Decode the public key from base64
+        let public_key_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&self.initialization_response.encryption_public_key)?;
+
+        // Deserialize the public key using HPKE trait
+        let public_key = <DhP256HkdfSha256 as hpke::Kem>::PublicKey::from_bytes(&public_key_bytes)
+            .map_err(|e| format!("Failed to deserialize public key: {:?}", e))?;
+
+        // Convert hex private key to bytes (remove 0x prefix if present)
+        let private_key_hex = private_key_hex
+            .strip_prefix("0x")
+            .unwrap_or(private_key_hex);
+        let private_key_bytes = hex::decode(private_key_hex)?;
+
+        // Setup HPKE sender context
+        let mut rng = rand::thread_rng();
+        let (encapsulated_key, mut encryption_context) =
+            hpke::setup_sender::<ChaCha20Poly1305, HkdfSha256, DhP256HkdfSha256, _>(
+                &OpModeS::Base,
+                &public_key,
+                &[],
+                &mut rng,
+            )
+            .map_err(|e| format!("HPKE setup failed: {:?}", e))?;
+
+        // Encrypt the private key
+        let ciphertext = encryption_context
+            .seal(&private_key_bytes, &[])
+            .map_err(|e| format!("HPKE encryption failed: {:?}", e))?;
+
+        // Encode results as base64
+        let ciphertext_b64 = base64::engine::general_purpose::STANDARD.encode(&ciphertext);
+        let encapsulated_key_b64 =
+            base64::engine::general_purpose::STANDARD.encode(&encapsulated_key.to_bytes());
+
+        Ok((ciphertext_b64, encapsulated_key_b64))
+    }
+
+    pub(crate) async fn submit(
+        self,
+        private_key_hex: &str,
+        owner: Option<WalletImportSubmissionRequestOwner>,
+        policy_ids: Vec<String>,
+        additional_signers: Vec<
+            crate::generated::types::WalletImportSubmissionRequestAdditionalSignersItem,
+        >,
+    ) -> Result<ResponseValue<Wallet>, Error<()>> {
+        // Encrypt the private key using HPKE
+        let (ciphertext, encapsulated_key) = self
+            .encrypt_private_key(private_key_hex)
+            .map_err(|_| Error::InvalidRequest("Failed to encrypt private key".to_string()))?;
+
+        // Create the wallet submission input
+        let wallet_input = PrivateKeySubmitInput {
+            address: self.address,
+            chain_type: self.chain_type,
+            ciphertext,
+            encapsulated_key,
+            encryption_type: self.initialization_response.encryption_type,
+            entropy_type: crate::generated::types::PrivateKeySubmitInputEntropyType::PrivateKey,
+        };
+
+        // Create the submission request
+        let submission_request = WalletImportSubmissionRequest {
+            wallet: WalletImportSubmissionRequestWallet::PrivateKeySubmitInput(wallet_input),
+            owner,
+            owner_id: None,
+            policy_ids,
+            additional_signers,
+        };
+
+        // Submit the import request
+        self.client.submit_import(&submission_request).await
+    }
+}

--- a/src/jwt_exchange.rs
+++ b/src/jwt_exchange.rs
@@ -103,6 +103,13 @@ impl JwtExchange {
             }
         };
 
+        // NOTE: ugly hack ahead
+        //
+        // privy's caches are a little slow sometimes which means we need to insert an
+        // artificial delay to increase the likelihood of the cache being populated.
+        // good news is that retries will not need a new key so retries will be fast.
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         {
             let mut cache = self.0.lock().expect("lock poisoned");
             cache.push(jwt.clone(), (expiry, key.clone()));

--- a/src/jwt_exchange.rs
+++ b/src/jwt_exchange.rs
@@ -85,15 +85,11 @@ impl JwtExchange {
             } => {
                 tracing::debug!("Received encrypted authorization key, starting HPKE decryption");
 
-                let key = hpke_manager
-                    .decrypt(
-                        &encrypted_authorization_key.encapsulated_key,
-                        &encrypted_authorization_key.ciphertext,
-                    )
-                    .map_err(|e| {
-                        tracing::error!("HPKE decryption failed: {:?}", e);
-                        KeyError::HpkeDecryption(format!("{e:?}"))
-                    })?;
+                let key = hpke_manager.decrypt(
+                    &encrypted_authorization_key.encapsulated_key,
+                    &encrypted_authorization_key.ciphertext,
+                )?;
+
                 let expiry = SystemTime::UNIX_EPOCH + Duration::from_secs_f64(expires_at);
                 (key, expiry)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,17 +36,3 @@ pub(crate) fn get_auth_header(app_id: &str, app_secret: &str) -> String {
     let credentials = format!("{app_id}:{app_secret}");
     format!("Basic {}", STANDARD.encode(credentials))
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn deserialize() {
-        let body = r#"{"id":"kra9fvbs9vo47ge1xs5x97k5","name":"test-policy-1757686660","chain_type":"solana","rules":[{"name":"test-rule","method":"signTransaction","conditions":[{"field_source":"solana_system_program_instruction","field":"Transfer.lamports","operator":"lt","value":"1000000"}],"action":"ALLOW","id":"h7ugroh0uaotl5khnc8xftdo"}],"version":"1.0","created_at":1757686660877,"owner_id":null}"#;
-
-        let jd = &mut serde_json::Deserializer::from_str(body);
-        let result: Result<super::generated::types::Policy, _> =
-            serde_path_to_error::deserialize(jd);
-
-        println!("{:?}", result.unwrap());
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod generated {
 pub mod subclients;
 
 pub(crate) mod errors;
+pub(crate) mod import;
 pub(crate) mod jwt_exchange;
 pub(crate) mod keys;
 pub(crate) mod utils;

--- a/src/privy_hpke.rs
+++ b/src/privy_hpke.rs
@@ -237,17 +237,10 @@ impl PrivyHpke {
             &self.private_key,
             &encapped_key,
             &[],
-        )
-        .map_err(|e| {
-            tracing::error!("HPKE setup failed: {:?}", e);
-            KeyError::HpkeDecryption(format!("HPKE setup failed: {e:?}"))
-        })?;
+        )?;
 
         // Decrypt the authorization key using the ciphertext
-        let decrypted_key_bytes = context.open(&ciphertext_bytes, &[]).map_err(|e| {
-            tracing::error!("HPKE decryption failed: {:?}", e);
-            KeyError::HpkeDecryption(format!("HPKE decryption failed: {e:?}"))
-        })?;
+        let decrypted_key_bytes = context.open(&ciphertext_bytes, &[])?;
 
         // Parse the decrypted bytes as a UTF-8 base64 DER string, then parse as a private key
         let key_b64 = String::from_utf8(decrypted_key_bytes)

--- a/src/privy_hpke.rs
+++ b/src/privy_hpke.rs
@@ -88,7 +88,7 @@ impl PrivyHpke {
     /// Creates a new ephemeral HPKE manager with a cryptographically secure P-256 keypair.
     #[must_use]
     pub fn new() -> Self {
-        let mut rng = rand::rng();
+        let mut rng = rand::thread_rng();
         let (private_key, public_key) = DhP256HkdfSha256::gen_keypair(&mut rng);
         Self {
             private_key,
@@ -102,7 +102,7 @@ impl PrivyHpke {
     /// This should only be used for testing purposes.
     #[cfg(test)]
     pub(crate) fn new_with_seed(seed: u64) -> Self {
-        use rand::SeedableRng;
+        use hpke::rand_core::SeedableRng;
         let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(seed);
         let (private_key, public_key) = DhP256HkdfSha256::gen_keypair(&mut rng);
         Self {

--- a/src/subclients.rs
+++ b/src/subclients.rs
@@ -325,7 +325,7 @@ impl WalletsClient {
         let privy_hpke = PrivyHpke::new();
         let body = WalletExportRequestBody {
             encryption_type: HpkeEncryption::Hpke,
-            recipient_public_key: privy_hpke.public_key().unwrap(),
+            recipient_public_key: privy_hpke.public_key()?,
         };
 
         let sig = generate_authorization_signatures(
@@ -362,14 +362,14 @@ impl WalletsClient {
             crate::generated::types::WalletImportInitializationRequest::PrivateKeyInitInput(
                 PrivateKeyInitInput {
                     address: address.clone(),
-                    chain_type: chain_type.clone(),
+                    chain_type,
                     encryption_type: HpkeEncryption::Hpke,
                     entropy_type:
                         crate::generated::types::PrivateKeyInitInputEntropyType::PrivateKey,
                 },
             ),
         )
-        .await
+        .await?
         .submit(private_key_hex, owner, policy_ids, additional_signers)
         .await
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::Result;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use privy_rs::{
-    PrivyApiError, PrivyClient, PrivySignedApiError, client::PrivyClientOptions,
+    PrivyApiError, PrivyClient, PrivyExportError, PrivySignedApiError, client::PrivyClientOptions,
     generated::types::*,
 };
 use serde::Serialize;
@@ -30,6 +30,16 @@ impl IntoApi for PrivySignedApiError {
 impl IntoApi for PrivyApiError {
     fn into_api(self) -> Result<PrivyApiError, Self> {
         Ok(self)
+    }
+}
+
+impl IntoApi for PrivyExportError {
+    fn into_api(self) -> Result<PrivyApiError, Self> {
+        match self {
+            PrivyExportError::Api(e) => Ok(e),
+            PrivyExportError::SignatureGeneration(_) => Err(self),
+            PrivyExportError::Key(_) => Err(self),
+        }
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![allow(dead_code)] // tests are compiled module by module so not all functions are used in every test
 
 use std::{
     env,

--- a/tests/fiat.rs
+++ b/tests/fiat.rs
@@ -14,15 +14,15 @@ async fn test_fiat_configure_app() -> Result<()> {
         api_key: "".parse()?,
     };
 
-    let result = client.fiat().configure_app(&app_id, &body).await;
+    let result = client.fiat().configure_app(app_id, &body).await;
 
     match result {
         Ok(response) => {
-            println!("Configure app response: {:?}", response);
+            println!("Configure app response: {response:?}");
             Ok(())
         }
         Err(e) => {
-            println!("Configure app failed (expected in test): {:?}", e);
+            println!("Configure app failed (expected in test): {e:?}");
             Ok(())
         }
     }
@@ -41,11 +41,11 @@ async fn test_fiat_get_status() -> Result<()> {
 
     match result {
         Ok(response) => {
-            println!("Fiat status response: {:?}", response);
+            println!("Fiat status response: {response:?}");
             Ok(())
         }
         Err(e) => {
-            println!("Get status failed (expected in test): {:?}", e);
+            println!("Get status failed (expected in test): {e:?}");
             Ok(())
         }
     }
@@ -69,11 +69,11 @@ async fn test_fiat_get_kyc_link() -> Result<()> {
 
     match result {
         Ok(response) => {
-            println!("KYC link response: {:?}", response);
+            println!("KYC link response: {response:?}");
             Ok(())
         }
         Err(e) => {
-            println!("Get KYC link failed (expected in test): {:?}", e);
+            println!("Get KYC link failed (expected in test): {e:?}");
             Ok(())
         }
     }
@@ -92,11 +92,11 @@ async fn test_fiat_accounts_get() -> Result<()> {
 
     match result {
         Ok(response) => {
-            println!("Fiat accounts response: {:?}", response);
+            println!("Fiat accounts response: {response:?}");
             Ok(())
         }
         Err(e) => {
-            println!("Get fiat accounts failed (expected in test): {:?}", e);
+            println!("Get fiat accounts failed (expected in test): {e:?}");
             Ok(())
         }
     }
@@ -124,11 +124,11 @@ async fn test_fiat_accounts_create() -> Result<()> {
 
     match result {
         Ok(response) => {
-            println!("Create fiat account response: {:?}", response);
+            println!("Create fiat account response: {response:?}");
             Ok(())
         }
         Err(e) => {
-            println!("Create fiat account failed (expected in test): {:?}", e);
+            println!("Create fiat account failed (expected in test): {e:?}");
             Ok(())
         }
     }
@@ -183,11 +183,11 @@ async fn test_fiat_kyc_create() -> Result<()> {
 
     match result {
         Ok(response) => {
-            println!("Initiate KYC response: {:?}", response);
+            println!("Initiate KYC response: {response:?}");
             Ok(())
         }
         Err(e) => {
-            println!("Initiate KYC failed (expected in test): {:?}", e);
+            println!("Initiate KYC failed (expected in test): {e:?}");
             Ok(())
         }
     }
@@ -216,11 +216,11 @@ async fn test_fiat_onramp_create() -> Result<()> {
 
     match result {
         Ok(response) => {
-            println!("Create onramp response: {:?}", response);
+            println!("Create onramp response: {response:?}");
             Ok(())
         }
         Err(e) => {
-            println!("Create onramp failed (expected in test): {:?}", e);
+            println!("Create onramp failed (expected in test): {e:?}");
             Ok(())
         }
     }
@@ -250,11 +250,11 @@ async fn test_fiat_offramp_create() -> Result<()> {
 
     match result {
         Ok(response) => {
-            println!("Create offramp response: {:?}", response);
+            println!("Create offramp response: {response:?}");
             Ok(())
         }
         Err(e) => {
-            println!("Create offramp failed (expected in test): {:?}", e);
+            println!("Create offramp failed (expected in test): {e:?}");
             Ok(())
         }
     }

--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -34,12 +34,11 @@ async fn test_transactions_get() -> Result<()> {
         // Test the transactions.get() endpoint
         let result = client.transactions().get(transaction_id).await?;
 
-        println!("Retrieved transaction: {:?}", result);
+        println!("Retrieved transaction: {result:?}");
         assert_eq!(result.into_inner().id, *transaction_id);
     } else {
         println!(
-            "No transactions found for wallet {}, skipping transaction get test",
-            wallet_id
+            "No transactions found for wallet {wallet_id}, skipping transaction get test"
         );
     }
 

--- a/tests/wallets.rs
+++ b/tests/wallets.rs
@@ -102,10 +102,9 @@ async fn test_wallets_authenticate_with_jwt() -> Result<()> {
 }
 
 #[tokio::test]
-#[ignore = "both solana and ethereum are 'not supported for this low-level signature endpoint'"]
 async fn test_wallets_raw_sign_with_auth_context() -> Result<()> {
     let client = get_test_client()?;
-    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Tron, None).await?;
 
     let raw_sign_body = privy_rs::generated::types::RawSign {
         params: RawSignParams {

--- a/tests/wallets.rs
+++ b/tests/wallets.rs
@@ -1,75 +1,729 @@
-#[tokio::test]
-#[ignore]
-async fn test_wallets_list() {}
+use std::str::FromStr;
+
+use anyhow::Result;
+use base64::{Engine, engine::general_purpose::STANDARD};
+use common::{ensure_test_user, get_test_client, get_test_wallet_id_by_type, mint_staging_jwt};
+use p256::elliptic_curve::SecretKey;
+use privy_openapi::types::{WalletAdditionalSigner, WalletAdditionalSignerItem};
+use privy_rs::{
+    AuthorizationContext, IntoKey, JwtUser, PrivateKey, PrivyHpke,
+    generated::types::{
+        AuthenticateBody, AuthenticateBodyEncryptionType, AuthenticateResponse, CreateWalletBody,
+        EthereumPersonalSignRpcInput, EthereumPersonalSignRpcInputChainType,
+        EthereumPersonalSignRpcInputMethod, EthereumPersonalSignRpcInputParams,
+        EthereumPersonalSignRpcInputParamsEncoding, EthereumSecp256k1SignRpcInput,
+        EthereumSendTransactionRpcInputChainType, EthereumSendTransactionRpcInputMethod,
+        EthereumSendTransactionRpcInputParams, EthereumSendTransactionRpcInputParamsTransaction,
+        EthereumSendTransactionRpcInputParamsTransactionValue,
+        EthereumSign7702AuthorizationRpcInput, EthereumSign7702AuthorizationRpcInputMethod,
+        EthereumSign7702AuthorizationRpcInputParams,
+        EthereumSign7702AuthorizationRpcInputParamsChainId, EthereumSignTypedDataRpcInput,
+        EthereumSignTypedDataRpcInputMethod, EthereumSignTypedDataRpcInputParams,
+        EthereumSignTypedDataRpcInputParamsTypedData,
+        EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem, GetWalletBalanceAsset,
+        GetWalletBalanceAssetString, GetWalletBalanceChain, GetWalletBalanceChainString,
+        GetWalletBalanceResponseBalancesItem, HpkeEncryption, OwnerInput, RawSignParams,
+        SolanaSignAndSendTransactionRpcInput, SolanaSignAndSendTransactionRpcInputCaip2,
+        SolanaSignAndSendTransactionRpcInputMethod, SolanaSignAndSendTransactionRpcInputParams,
+        SolanaSignAndSendTransactionRpcInputParamsEncoding, SolanaSignMessageRpcInput,
+        SolanaSignMessageRpcInputMethod, SolanaSignMessageRpcInputParams,
+        SolanaSignMessageRpcInputParamsEncoding, SolanaSignTransactionRpcInput,
+        SolanaSignTransactionRpcInputMethod, SolanaSignTransactionRpcInputParams,
+        SolanaSignTransactionRpcInputParamsEncoding, UpdateWalletBody, UserLinkedAccountsItem,
+        WalletChainType, WalletExportRequestBody, WalletRpcBody, WalletTransactionsAsset,
+        WalletTransactionsAssetString, WalletTransactionsChain,
+    },
+};
+use solana_sdk::{pubkey::Pubkey, transaction::Transaction};
+use tracing_test::traced_test;
+
+mod common;
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_create() {}
+async fn test_wallets_list() -> Result<()> {
+    let client = get_test_client()?;
+    let wallets = client.wallets().list(None, None, Some(10.0), None).await?;
+
+    println!("Retrieved {} wallets", wallets.data.len());
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_get() {}
+async fn test_wallets_create() -> Result<()> {
+    let client = get_test_client()?;
+
+    let create_body = CreateWalletBody {
+        chain_type: WalletChainType::Solana,
+        additional_signers: None,
+        owner: None,
+        owner_id: None,
+        policy_ids: vec![],
+    };
+
+    let wallet = client.wallets().create(None, &create_body).await?;
+
+    assert_eq!(wallet.chain_type, WalletChainType::Solana);
+    println!("Created wallet with ID: {:?}", wallet.id);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_authenticate_with_jwt() {}
+async fn test_wallets_get() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Solana, None).await?;
+
+    let wallet = debug_response!(client.wallets().get(&wallet_id)).await?;
+
+    assert_eq!(wallet.id, wallet_id);
+    assert_eq!(wallet.chain_type, WalletChainType::Solana);
+
+    println!("Retrieved wallet: {:?}", wallet.id);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_rpc_with_auth_context() {}
+#[traced_test]
+async fn test_wallets_authenticate_with_jwt() -> Result<()> {
+    let client = get_test_client()?;
+    let user = ensure_test_user(&client).await?;
+
+    // authenticate requires that the user own at least one wallet
+    let _wallet =
+        get_test_wallet_id_by_type(&client, WalletChainType::Solana, Some(&user.id)).await?;
+
+    let custom_auth = user
+        .linked_accounts
+        .iter()
+        .find_map(|la| match la {
+            UserLinkedAccountsItem::CustomJwt(jwt) => Some(jwt.custom_user_id.to_owned()),
+            _ => None,
+        })
+        .unwrap();
+
+    let jwt_token = mint_staging_jwt(&custom_auth)?;
+
+    tracing::info!("JWT token: {:?}", jwt_token);
+
+    let privy_hpke = PrivyHpke::new();
+    let auth_body = AuthenticateBody {
+        encryption_type: Some(AuthenticateBodyEncryptionType::Hpke),
+        user_jwt: jwt_token,
+        recipient_public_key: Some(privy_hpke.public_key().unwrap()),
+    };
+
+    let result = debug_response!(client.wallets().authenticate_with_jwt(&auth_body)).await?;
+
+    match result.into_inner() {
+        AuthenticateResponse::WithEncryption { .. } => {
+            println!("JWT authentication successful for user: {}", user.id);
+        }
+        _ => panic!("Unexpected response type"),
+    }
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_raw_sign_with_auth_context() {}
+#[ignore = "both solana and ethereum are 'not supported for this low-level signature endpoint'"]
+async fn test_wallets_raw_sign_with_auth_context() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
+
+    let raw_sign_body = privy_rs::generated::types::RawSign {
+        params: RawSignParams {
+            hash: Some("0xdeadbeef".to_string()),
+        },
+    };
+
+    let ctx = AuthorizationContext::new();
+
+    let result = debug_response!(
+        client
+            .wallets()
+            .raw_sign(&wallet_id, &ctx, None, &raw_sign_body)
+    )
+    .await?;
+
+    let sig = result.into_inner().data.signature;
+
+    assert_ne!(sig.len(), 0);
+    println!("Raw signature created: {:?}", sig);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_update_with_auth_context() {}
+async fn test_wallets_update_with_auth_context() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Solana, None).await?;
+
+    let private_key = include_str!("./test_private_key.pem");
+
+    // Get a public key for the update (use existing or generate one)
+    let private_key = PrivateKey(private_key.to_string());
+    let public_key = private_key.get_key().await?.public_key();
+
+    let update_body = UpdateWalletBody {
+        owner: Some(OwnerInput::PublicKey(public_key.to_string())),
+        ..Default::default()
+    };
+
+    let ctx = AuthorizationContext::new();
+
+    // add an owner to the wallet
+    let _wallet = debug_response!(client.wallets().update(&wallet_id, &ctx, &update_body)).await?;
+
+    let mut rng = rand::thread_rng();
+    let other = SecretKey::random(&mut rng);
+
+    let update_body = UpdateWalletBody {
+        owner: Some(OwnerInput::PublicKey(public_key.to_string())),
+        ..Default::default()
+    };
+
+    // we now have an owner, lets try to update, and expect an error
+    if let Ok(_) = client
+        .wallets()
+        .update(&wallet_id, &ctx, &update_body)
+        .await
+    {
+        panic!("Expected an error when removing an owner");
+    }
+
+    ctx.push(private_key);
+
+    let wallet = debug_response!(client.wallets().update(&wallet_id, &ctx, &update_body)).await?;
+
+    assert_eq!(wallet.id, wallet_id);
+    println!("Updated wallet owner for: {}", wallet_id);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_export() {}
+async fn test_wallets_export() -> Result<()> {
+    let client = get_test_client()?;
+    let user = ensure_test_user(&client).await?;
+    let wallet_id =
+        get_test_wallet_id_by_type(&client, WalletChainType::Solana, Some(&user.id)).await?;
+
+    let sub = user
+        .linked_accounts
+        .iter()
+        .find_map(|u| match u {
+            UserLinkedAccountsItem::CustomJwt(jwt) => Some(&jwt.custom_user_id),
+            _ => None,
+        })
+        .unwrap();
+
+    let privy_hpke = PrivyHpke::new();
+    let export_body = WalletExportRequestBody {
+        encryption_type: HpkeEncryption::Hpke,
+        recipient_public_key: privy_hpke.public_key().unwrap(),
+    };
+
+    let ctx = AuthorizationContext::new();
+    let jwt = mint_staging_jwt(&sub)?;
+    ctx.push(JwtUser(client.clone(), jwt));
+
+    let exported = debug_response!(client.wallets().export(&wallet_id, &ctx, &export_body)).await?;
+
+    println!("Wallet exported successfully {:?}", exported);
+
+    assert_eq!(exported.encryption_type, HpkeEncryption::Hpke);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_transactions_get() {}
+#[ignore = "openapi reports base as only chain type which is not supported"]
+async fn test_wallets_transactions_get() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
+
+    let asset = WalletTransactionsAsset::String(WalletTransactionsAssetString::Eth);
+    let chain = WalletTransactionsChain::Base;
+
+    let transactions = debug_response!(client.wallets().transactions().get(
+        &wallet_id,
+        &asset,
+        chain,
+        None,
+        Some(10.0)
+    ))
+    .await?;
+
+    println!(
+        "Retrieved {} transactions",
+        transactions.into_inner().transactions.len()
+    );
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_balance_get() {}
+async fn test_wallets_balance_get() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Solana, None).await?;
+
+    let asset = GetWalletBalanceAsset::String(GetWalletBalanceAssetString::Sol);
+    let chain = GetWalletBalanceChain::String(GetWalletBalanceChainString::Solana);
+
+    let balance = debug_response!(
+        client
+            .wallets()
+            .balance()
+            .get(&wallet_id, &asset, &chain, None)
+    )
+    .await?;
+
+    let balance = balance.into_inner();
+
+    println!("Wallet balance retrieved: {:?}", balance);
+
+    // new wallet, must be 0
+    match balance.balances.as_slice() {
+        [
+            GetWalletBalanceResponseBalancesItem {
+                raw_value_decimals, ..
+            },
+        ] => {
+            assert_eq!(*raw_value_decimals, 0.0);
+        }
+        resp => panic!("Unexpected balance response {:?}", resp),
+    }
+
+    Ok(())
+}
+
+// Chain-specific signing tests - these would need actual chain-specific implementations
+// For now, these are placeholders that demonstrate the testing structure
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_solana_sign_message() {}
+async fn test_wallets_solana_sign_message() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Solana, None).await?;
+
+    let message = "Hello, Solana!";
+    let rpc_body = WalletRpcBody::SolanaSignMessageRpcInput(SolanaSignMessageRpcInput {
+        address: None,
+        chain_type: None,
+        method: SolanaSignMessageRpcInputMethod::SignMessage,
+        params: SolanaSignMessageRpcInputParams {
+            encoding: SolanaSignMessageRpcInputParamsEncoding::Base64,
+            message: STANDARD.encode(message),
+        },
+    });
+
+    let result = debug_response!(client.wallets().rpc(
+        &wallet_id,
+        &AuthorizationContext::new(),
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    println!("Solana message signed successfully: {:?}", result);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_solana_sign_transaction() {}
+async fn test_wallets_solana_sign_transaction() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Solana, None).await?;
+
+    // Example base64-encoded Solana transaction (simplified for testing)
+    let transaction = "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDArczbMia1tLmq7zz4DinMNN0pJ1JtLdqIJPUw3YrGCzYAMHBsgN27lcgB6H2WQvFgyZuJYHa46puOQo9yQ8CVQbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCp20C7Wj2aiuk5TReAXo+VTVg8QTHjs0UjNMMKCvpzZ+ABAgEBARU=";
+
+    let rpc_body = WalletRpcBody::SolanaSignTransactionRpcInput(SolanaSignTransactionRpcInput {
+        address: None,
+        chain_type: None,
+        method: SolanaSignTransactionRpcInputMethod::SignTransaction,
+        params: SolanaSignTransactionRpcInputParams {
+            encoding: SolanaSignTransactionRpcInputParamsEncoding::Base64,
+            transaction: transaction.to_string(),
+        },
+    });
+
+    let result = debug_response!(client.wallets().rpc(
+        &wallet_id,
+        &AuthorizationContext::new(),
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    println!("Solana transaction signed successfully: {:?}", result);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_solana_sign_and_send_transaction() {}
+#[traced_test]
+#[mark_flaky_tests::flaky]
+async fn test_wallets_solana_sign_and_send_transaction() -> Result<()> {
+    let client = get_test_client()?;
+
+    let funded_solana_wallet_id =
+        std::env::var("FUNDED_SOLANA_WALLET_ID").unwrap_or("av73ge0tfe2xqborg9vjushr".to_string());
+    let funded_solana_wallet_address = std::env::var("FUNDED_SOLANA_WALLET_ADDRESS")
+        .unwrap_or("DTeASnDsQ1z9Le77MjuiPH4MyqLDWa9vB6R3ZZKRd8d3".to_string());
+
+    // re-using the wallet the java-sdk uses rather than maintaining a parallel wallet
+    let funded_solana_wallet_owner_subject_id =
+        std::env::var("FUNDED_SOLANA_WALLET_OWNER_SUBJECT_ID")
+            .unwrap_or("java-sdk-sub-id".to_string());
+
+    let from_pubkey = Pubkey::from_str(&funded_solana_wallet_address).unwrap();
+    let to_pubkey = Pubkey::from_str(&funded_solana_wallet_address).unwrap();
+    let lamports = 100;
+
+    let transaction = Transaction::new_with_payer(
+        &[solana_system_interface::instruction::transfer(
+            &from_pubkey,
+            &to_pubkey,
+            lamports,
+        )],
+        None,
+    );
+
+    // bincode then base64 encode
+    let transaction = STANDARD.encode(bincode::serialize(&transaction).unwrap());
+
+    let rpc_body =
+        WalletRpcBody::SolanaSignAndSendTransactionRpcInput(SolanaSignAndSendTransactionRpcInput {
+            address: None,
+            caip2: SolanaSignAndSendTransactionRpcInputCaip2::from_str(
+                "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1", // devnet
+            )
+            .unwrap(),
+            chain_type: None,
+            method: SolanaSignAndSendTransactionRpcInputMethod::SignAndSendTransaction,
+            params: SolanaSignAndSendTransactionRpcInputParams {
+                encoding: SolanaSignAndSendTransactionRpcInputParamsEncoding::Base64,
+                transaction,
+            },
+            sponsor: Some(false),
+        });
+
+    let ctx = AuthorizationContext::new();
+    ctx.push(JwtUser(
+        client.clone(),
+        mint_staging_jwt(&funded_solana_wallet_owner_subject_id)?,
+    ));
+
+    let result = debug_response!(client.wallets().rpc(
+        &funded_solana_wallet_id,
+        &ctx,
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    println!(
+        "Solana transaction signed and sent successfully: {:?}",
+        result
+    );
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_ethereum_sign_message() {}
+#[traced_test]
+#[mark_flaky_tests::flaky]
+async fn test_wallets_ethereum_sign_message() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
+
+    let rpc_body: WalletRpcBody =
+        WalletRpcBody::EthereumPersonalSignRpcInput(EthereumPersonalSignRpcInput {
+            address: Some("0xdadB0d80178819F2319190D340ce9A924f783711".to_string()),
+            chain_type: Some(EthereumPersonalSignRpcInputChainType::Ethereum),
+            method: EthereumPersonalSignRpcInputMethod::PersonalSign,
+            params: EthereumPersonalSignRpcInputParams {
+                encoding: EthereumPersonalSignRpcInputParamsEncoding::Utf8,
+                message: "Hello world".to_string(),
+            },
+        });
+
+    let result = debug_response!(client.wallets().rpc(
+        &wallet_id,
+        &AuthorizationContext::new(),
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    // Just verify we got a valid response
+    println!("Ethereum message signed via RPC: {:?}", result);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_ethereum_sign_typed_data() {}
+async fn test_wallets_ethereum_sign_typed_data() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
+
+    let rpc_body = WalletRpcBody::EthereumSignTypedDataRpcInput(EthereumSignTypedDataRpcInput {
+        address: None,
+        chain_type: None,
+        method: EthereumSignTypedDataRpcInputMethod::EthSignTypedDataV4,
+        params: EthereumSignTypedDataRpcInputParams {
+            typed_data: EthereumSignTypedDataRpcInputParamsTypedData {
+                domain: serde_json::Map::from_iter([
+                    ("name".to_string(), serde_json::json!("DApp Mail")),
+                    ("version".to_string(), serde_json::json!("1")),
+                    ("chainId".to_string(), serde_json::json!("0x3e8")),
+                    (
+                        "verifyingContract".to_string(),
+                        serde_json::json!("0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"),
+                    ),
+                ]),
+                message: serde_json::Map::from_iter([
+                    (
+                        "from".to_string(),
+                        serde_json::json!({
+                            "name": "Alice",
+                            "wallet": "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"
+                        }),
+                    ),
+                    (
+                        "to".to_string(),
+                        serde_json::json!({
+                            "name": "Bob",
+                            "wallet": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+                        }),
+                    ),
+                    ("contents".to_string(), serde_json::json!("Hello, Bob!")),
+                ]),
+                primary_type: "Mail".to_string(),
+                types: [
+                    (
+                        "EIP712Domain".to_string(),
+                        vec![
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "name".to_string(),
+                                type_: "string".to_string(),
+                            },
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "version".to_string(),
+                                type_: "string".to_string(),
+                            },
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "chainId".to_string(),
+                                type_: "uint256".to_string(),
+                            },
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "verifyingContract".to_string(),
+                                type_: "address".to_string(),
+                            },
+                        ],
+                    ),
+                    (
+                        "Person".to_string(),
+                        vec![
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "name".to_string(),
+                                type_: "string".to_string(),
+                            },
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "wallet".to_string(),
+                                type_: "address".to_string(),
+                            },
+                        ],
+                    ),
+                    (
+                        "Mail".to_string(),
+                        vec![
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "from".to_string(),
+                                type_: "Person".to_string(),
+                            },
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "to".to_string(),
+                                type_: "Person".to_string(),
+                            },
+                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                                name: "contents".to_string(),
+                                type_: "string".to_string(),
+                            },
+                        ],
+                    ),
+                ]
+                .into(),
+            },
+        },
+    });
+
+    let result = debug_response!(client.wallets().rpc(
+        &wallet_id,
+        &AuthorizationContext::new(),
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    // Just verify we got a valid response
+    println!("Ethereum typed data signed via RPC: {:?}", result);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_ethereum_sign_secp256k1() {}
+async fn test_wallets_ethereum_sign_secp256k1() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
+
+    let rpc_body = WalletRpcBody::EthereumSecp256k1SignRpcInput(EthereumSecp256k1SignRpcInput {
+        address: None,
+        chain_type: None,
+        method: privy_rs::generated::types::EthereumSecp256k1SignRpcInputMethod::Secp256k1Sign,
+        params: privy_rs::generated::types::EthereumSecp256k1SignRpcInputParams {
+            hash: "0x12345678".to_string(),
+        },
+    });
+
+    let result = debug_response!(client.wallets().rpc(
+        &wallet_id,
+        &AuthorizationContext::new(),
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    // Just verify we got a valid response
+    println!("Ethereum secp256k1 signature via RPC: {:?}", result);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_ethereum_sign_7702_authorization() {}
+async fn test_wallets_ethereum_sign_7702_authorization() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
+
+    let rpc_body = WalletRpcBody::EthereumSign7702AuthorizationRpcInput(
+        EthereumSign7702AuthorizationRpcInput {
+            address: None,
+            chain_type: None,
+            method: EthereumSign7702AuthorizationRpcInputMethod::EthSign7702Authorization,
+            params: EthereumSign7702AuthorizationRpcInputParams {
+                chain_id: EthereumSign7702AuthorizationRpcInputParamsChainId::Integer(1),
+                contract: "0x1234567890abcdef1234567890abcdef12345678".into(),
+                nonce: None,
+            },
+        },
+    );
+
+    let result = debug_response!(client.wallets().rpc(
+        &wallet_id,
+        &AuthorizationContext::new(),
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    // Just verify we got a valid response
+    println!("Ethereum 7702 authorization signed via RPC: {:?}", result);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_ethereum_sign_transaction() {}
+#[ignore = "failing with 'unexpected error occurred, please try again later'"]
+async fn test_wallets_ethereum_sign_transaction() -> Result<()> {
+    let client = get_test_client()?;
+    let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
+
+    let rpc_body = WalletRpcBody::EthereumSignTransactionRpcInput(
+        privy_rs::generated::types::EthereumSignTransactionRpcInput {
+            address: Some("0xdadB0d80178819F2319190D340ce9A924f783711".to_string()),
+            chain_type: Some(privy_rs::generated::types::EthereumSignTransactionRpcInputChainType::Ethereum),
+            method: privy_rs::generated::types::EthereumSignTransactionRpcInputMethod::EthSignTransaction,
+            params: privy_rs::generated::types::EthereumSignTransactionRpcInputParams {
+                transaction: privy_rs::generated::types::EthereumSignTransactionRpcInputParamsTransaction {
+                    chain_id: None, data: None, from: None, gas_limit: None, gas_price: None, max_fee_per_gas: None, max_priority_fee_per_gas: None, nonce: None, to: None, type_: None, value: None
+                }
+            },
+        },
+    );
+
+    let result = debug_response!(client.wallets().rpc(
+        &wallet_id,
+        &AuthorizationContext::new(),
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    // Just verify we got a valid response
+    println!("Ethereum transaction signed via RPC: {:?}", result);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_wallets_ethereum_send_transaction() {}
+#[traced_test]
+// #[mark_flaky_tests::flaky]
+async fn test_wallets_ethereum_send_transaction() -> Result<()> {
+    let client = get_test_client()?;
+
+    let funded_ethereum_wallet_id = std::env::var("FUNDED_ETHEREUM_WALLET_ID")
+        .unwrap_or("xdeor1731y8gme1utsldxynv".to_string());
+    let funded_ethereum_wallet_address = std::env::var("FUNDED_ETHEREUM_WALLET_ADDRESS")
+        .unwrap_or("0xd606c61A275328395E15375A0139Ef92DA9cC280".to_string());
+    let funded_ethereum_wallet_owner_subject_id =
+        std::env::var("FUNDED_WALLETS_OWNER_SUBJECT_ID").unwrap_or("java-sdk-sub-id".to_string());
+
+    let rpc_body = WalletRpcBody::EthereumSendTransactionRpcInput(
+        privy_rs::generated::types::EthereumSendTransactionRpcInput {
+            address: None,
+            caip2: "eip155:11155111".parse().unwrap(),
+            chain_type: Some(EthereumSendTransactionRpcInputChainType::Ethereum),
+            method: EthereumSendTransactionRpcInputMethod::EthSendTransaction,
+            params: EthereumSendTransactionRpcInputParams {
+                transaction: EthereumSendTransactionRpcInputParamsTransaction {
+                    to: Some("0xa8BABAc2A6d66Db720D8271e7a85fB0CB78A5377".to_string()),
+                    value: Some(
+                        EthereumSendTransactionRpcInputParamsTransactionValue::Integer(100),
+                    ),
+                    chain_id: None,
+                    from: Some(funded_ethereum_wallet_address.clone()),
+                    max_fee_per_gas: None,
+                    max_priority_fee_per_gas: None,
+                    nonce: None,
+                    type_: None,
+                    data: Some("0x".to_string()),
+                    // data: None,
+                    gas_limit: None,
+                    gas_price: None,
+                },
+            },
+            sponsor: Some(false),
+        },
+    );
+
+    let ctx = AuthorizationContext::new();
+    ctx.push(JwtUser(
+        client.clone(),
+        mint_staging_jwt(&funded_ethereum_wallet_owner_subject_id)?,
+    ));
+
+    let result = debug_response!(client.wallets().rpc(
+        &funded_ethereum_wallet_id,
+        &ctx,
+        None,
+        &rpc_body
+    ))
+    .await?;
+
+    // Just verify we got a valid response
+    println!("Ethereum transaction sent via RPC: {:?}", result);
+
+    Ok(())
+}

--- a/tests/wallets.rs
+++ b/tests/wallets.rs
@@ -124,7 +124,7 @@ async fn test_wallets_raw_sign_with_auth_context() -> Result<()> {
     let sig = result.into_inner().data.signature;
 
     assert_ne!(sig.len(), 0);
-    println!("Raw signature created: {:?}", sig);
+    println!("Raw signature created: {sig:?}");
 
     Ok(())
 }
@@ -159,10 +159,11 @@ async fn test_wallets_update_with_auth_context() -> Result<()> {
     };
 
     // we now have an owner, lets try to update, and expect an error
-    if let Ok(_) = client
+    if client
         .wallets()
         .update(&wallet_id, &ctx, &update_body)
         .await
+        .is_ok()
     {
         panic!("Expected an error when removing an owner");
     }
@@ -172,7 +173,7 @@ async fn test_wallets_update_with_auth_context() -> Result<()> {
     let wallet = debug_response!(client.wallets().update(&wallet_id, &ctx, &update_body)).await?;
 
     assert_eq!(wallet.id, wallet_id);
-    println!("Updated wallet owner for: {}", wallet_id);
+    println!("Updated wallet owner for: {wallet_id}");
 
     Ok(())
 }
@@ -194,12 +195,12 @@ async fn test_wallets_export() -> Result<()> {
         .unwrap();
 
     let ctx = AuthorizationContext::new();
-    let jwt = mint_staging_jwt(&sub)?;
+    let jwt = mint_staging_jwt(sub)?;
     ctx.push(JwtUser(client.clone(), jwt));
 
     let exported = debug_response!(client.wallets().export(&wallet_id, &ctx)).await?;
 
-    println!("Wallet exported successfully {:?}", exported);
+    println!("Wallet exported successfully {exported:?}");
 
     Ok(())
 }
@@ -248,7 +249,7 @@ async fn test_wallets_balance_get() -> Result<()> {
 
     let balance = balance.into_inner();
 
-    println!("Wallet balance retrieved: {:?}", balance);
+    println!("Wallet balance retrieved: {balance:?}");
 
     // new wallet, must be 0
     match balance.balances.as_slice() {
@@ -259,7 +260,7 @@ async fn test_wallets_balance_get() -> Result<()> {
         ] => {
             assert_eq!(*raw_value_decimals, 0.0);
         }
-        resp => panic!("Unexpected balance response {:?}", resp),
+        resp => panic!("Unexpected balance response {resp:?}"),
     }
 
     Ok(())
@@ -292,7 +293,7 @@ async fn test_wallets_solana_sign_message() -> Result<()> {
     ))
     .await?;
 
-    println!("Solana message signed successfully: {:?}", result);
+    println!("Solana message signed successfully: {result:?}");
 
     Ok(())
 }
@@ -323,7 +324,7 @@ async fn test_wallets_solana_sign_transaction() -> Result<()> {
     ))
     .await?;
 
-    println!("Solana transaction signed successfully: {:?}", result);
+    println!("Solana transaction signed successfully: {result:?}");
 
     Ok(())
 }
@@ -390,10 +391,7 @@ async fn test_wallets_solana_sign_and_send_transaction() -> Result<()> {
     ))
     .await?;
 
-    println!(
-        "Solana transaction signed and sent successfully: {:?}",
-        result
-    );
+    println!("Solana transaction signed and sent successfully: {result:?}");
 
     Ok(())
 }
@@ -425,7 +423,7 @@ async fn test_wallets_ethereum_sign_message() -> Result<()> {
     .await?;
 
     // Just verify we got a valid response
-    println!("Ethereum message signed via RPC: {:?}", result);
+    println!("Ethereum message signed via RPC: {result:?}");
 
     Ok(())
 }
@@ -535,7 +533,7 @@ async fn test_wallets_ethereum_sign_typed_data() -> Result<()> {
     .await?;
 
     // Just verify we got a valid response
-    println!("Ethereum typed data signed via RPC: {:?}", result);
+    println!("Ethereum typed data signed via RPC: {result:?}");
 
     Ok(())
 }
@@ -563,7 +561,7 @@ async fn test_wallets_ethereum_sign_secp256k1() -> Result<()> {
     .await?;
 
     // Just verify we got a valid response
-    println!("Ethereum secp256k1 signature via RPC: {:?}", result);
+    println!("Ethereum secp256k1 signature via RPC: {result:?}");
 
     Ok(())
 }
@@ -595,7 +593,7 @@ async fn test_wallets_ethereum_sign_7702_authorization() -> Result<()> {
     .await?;
 
     // Just verify we got a valid response
-    println!("Ethereum 7702 authorization signed via RPC: {:?}", result);
+    println!("Ethereum 7702 authorization signed via RPC: {result:?}");
 
     Ok(())
 }
@@ -628,7 +626,7 @@ async fn test_wallets_ethereum_sign_transaction() -> Result<()> {
     .await?;
 
     // Just verify we got a valid response
-    println!("Ethereum transaction signed via RPC: {:?}", result);
+    println!("Ethereum transaction signed via RPC: {result:?}");
 
     Ok(())
 }
@@ -689,7 +687,7 @@ async fn test_wallets_ethereum_send_transaction() -> Result<()> {
     .await?;
 
     // Just verify we got a valid response
-    println!("Ethereum transaction sent via RPC: {:?}", result);
+    println!("Ethereum transaction sent via RPC: {result:?}");
 
     Ok(())
 }
@@ -710,7 +708,7 @@ async fn test_ethereum_wallet_import() -> Result<()> {
     // address is the last 20 bytes of the keccak256 hash of the public key
     let address: String = format!(
         "0x{}",
-        sha3::Keccak256::digest(&public)[12..]
+        sha3::Keccak256::digest(public)[12..]
             .iter()
             .encode_hex::<String>()
     );


### PR DESCRIPTION
blocked on a few things:
- [x] export is reporting 'No valid user session keys available'
- [x] the RPC endpoint tests are only passing with a 20% success rate (ish). Most of the time it reports that app id is not provided.
- [x] one of the tests (rpc send transactions) are ignored due to lacking funds
- [ ] raw sign is ignored because the api reports that both solana and eth are 'not supported for this low level endpoint'
- [ ] transactions are ignored because the openai schema reports 'base' as the only chain type which is not supported 