### PR TITLE
add e2e tests for policies service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
+ "serde_path_to_error",
  "serde_yaml",
  "sha2",
  "spki",
@@ -1872,18 +1873,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "6aaeb1e94f53b16384af593c71e20b095e958dab1d26939c1b70645c5cfbcc0b"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.224"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f39390fa6346e24defbcdd3d9544ba8a19985d0af74df8501fbfe9a64341ab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.224"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "87ff78ab5e8561c9a675bfc1785cb07ae721f0ee53329a595cefd8c04c2ac4e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1922,6 +1933,17 @@ dependencies = [
  "ryu-js",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ tempfile = "3.0"
 # used for deterministic key generation under testing
 rand_chacha = "0.9.0"
 hex = "0.4"
+serde_path_to_error = "0.1.17"
 
 # uuid again here since we don't need feature v4 outside of dev deps
 uuid = { version = "1.18.1", features = ["v4"] }

--- a/crates/privy-openapi/src/lib.rs
+++ b/crates/privy-openapi/src/lib.rs
@@ -1823,13 +1823,11 @@ pub mod types {
     #[doc = "        \"1.0\""]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct CreatePolicyBody {
         pub chain_type: PolicyChainType,
         #[doc = "Name to assign to policy."]
@@ -5758,8 +5756,7 @@ pub mod types {
     #[doc = "                \"signer_id\": {"]
     #[doc = "                  \"type\": \"string\""]
     #[doc = "                }"]
-    #[doc = "              },"]
-    #[doc = "              \"additionalProperties\": false"]
+    #[doc = "              }"]
     #[doc = "            }"]
     #[doc = "          },"]
     #[doc = "          \"chain_type\": {"]
@@ -5788,8 +5785,7 @@ pub mod types {
     #[doc = "            },"]
     #[doc = "            \"maxItems\": 1"]
     #[doc = "          }"]
-    #[doc = "        },"]
-    #[doc = "        \"additionalProperties\": false"]
+    #[doc = "        }"]
     #[doc = "      }"]
     #[doc = "    }"]
     #[doc = "  }"]
@@ -5834,8 +5830,7 @@ pub mod types {
     #[doc = "          \"signer_id\": {"]
     #[doc = "            \"type\": \"string\""]
     #[doc = "          }"]
-    #[doc = "        },"]
-    #[doc = "        \"additionalProperties\": false"]
+    #[doc = "        }"]
     #[doc = "      }"]
     #[doc = "    },"]
     #[doc = "    \"chain_type\": {"]
@@ -5864,13 +5859,11 @@ pub mod types {
     #[doc = "      },"]
     #[doc = "      \"maxItems\": 1"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct CreateUserWalletBodyWalletsItem {
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub additional_signers:
@@ -5907,13 +5900,11 @@ pub mod types {
     #[doc = "    \"signer_id\": {"]
     #[doc = "      \"type\": \"string\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct CreateUserWalletBodyWalletsItemAdditionalSignersItem {
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub override_policy_ids: ::std::vec::Vec<::std::string::String>,
@@ -6999,16 +6990,13 @@ pub mod types {
     #[doc = "        \"message\": {"]
     #[doc = "          \"type\": \"string\""]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumPersonalSignRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -7197,13 +7185,11 @@ pub mod types {
     #[doc = "    \"message\": {"]
     #[doc = "      \"type\": \"string\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumPersonalSignRpcInputParams {
         pub encoding: EthereumPersonalSignRpcInputParamsEncoding,
         pub message: ::std::string::String,
@@ -7574,16 +7560,13 @@ pub mod types {
     #[doc = "        \"hash\": {"]
     #[doc = "          \"type\": \"string\""]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSecp256k1SignRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -7755,13 +7738,11 @@ pub mod types {
     #[doc = "    \"hash\": {"]
     #[doc = "      \"type\": \"string\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSecp256k1SignRpcInputParams {
         pub hash: ::std::string::String,
     }
@@ -8163,22 +8144,18 @@ pub mod types {
     #[doc = "                }"]
     #[doc = "              ]"]
     #[doc = "            }"]
-    #[doc = "          },"]
-    #[doc = "          \"additionalProperties\": false"]
+    #[doc = "          }"]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    },"]
     #[doc = "    \"sponsor\": {"]
     #[doc = "      \"type\": \"boolean\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSendTransactionRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -8549,16 +8526,13 @@ pub mod types {
     #[doc = "            }"]
     #[doc = "          ]"]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSendTransactionRpcInputParams {
         pub transaction: EthereumSendTransactionRpcInputParamsTransaction,
     }
@@ -8692,13 +8666,11 @@ pub mod types {
     #[doc = "        }"]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSendTransactionRpcInputParamsTransaction {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub chain_id:
@@ -9438,8 +9410,7 @@ pub mod types {
     #[doc = "                }"]
     #[doc = "              ]"]
     #[doc = "            }"]
-    #[doc = "          },"]
-    #[doc = "          \"additionalProperties\": false"]
+    #[doc = "          }"]
     #[doc = "        }"]
     #[doc = "      }"]
     #[doc = "    },"]
@@ -9605,8 +9576,7 @@ pub mod types {
     #[doc = "            }"]
     #[doc = "          ]"]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
     #[doc = "  }"]
     #[doc = "}"]
@@ -9837,13 +9807,11 @@ pub mod types {
     #[doc = "        }"]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSendTransactionRpcResponseDataTransactionRequest {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub chain_id:
@@ -10621,16 +10589,13 @@ pub mod types {
     #[doc = "            }"]
     #[doc = "          ]"]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSign7702AuthorizationRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -10837,13 +10802,11 @@ pub mod types {
     #[doc = "        }"]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSign7702AuthorizationRpcInputParams {
         pub chain_id: EthereumSign7702AuthorizationRpcInputParamsChainId,
         pub contract: ::std::string::String,
@@ -11500,19 +11463,15 @@ pub mod types {
     #[doc = "                }"]
     #[doc = "              ]"]
     #[doc = "            }"]
-    #[doc = "          },"]
-    #[doc = "          \"additionalProperties\": false"]
+    #[doc = "          }"]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSignTransactionRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -11799,16 +11758,13 @@ pub mod types {
     #[doc = "            }"]
     #[doc = "          ]"]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSignTransactionRpcInputParams {
         pub transaction: EthereumSignTransactionRpcInputParamsTransaction,
     }
@@ -11942,13 +11898,11 @@ pub mod types {
     #[doc = "        }"]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSignTransactionRpcInputParamsTransaction {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub chain_id:
@@ -12852,19 +12806,15 @@ pub mod types {
     #[doc = "                }"]
     #[doc = "              }"]
     #[doc = "            }"]
-    #[doc = "          },"]
-    #[doc = "          \"additionalProperties\": false"]
+    #[doc = "          }"]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSignTypedDataRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -13074,16 +13024,13 @@ pub mod types {
     #[doc = "            }"]
     #[doc = "          }"]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSignTypedDataRpcInputParams {
         pub typed_data: EthereumSignTypedDataRpcInputParamsTypedData,
     }
@@ -13140,13 +13087,11 @@ pub mod types {
     #[doc = "        }"]
     #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct EthereumSignTypedDataRpcInputParamsTypedData {
         pub domain: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
         pub message: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
@@ -26851,13 +26796,11 @@ pub mod types {
     #[doc = "        \"apple_oauth\""]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountAppleInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub email: ::std::option::Option<::std::string::String>,
@@ -28836,13 +28779,11 @@ pub mod types {
     #[doc = "        \"custom_auth\""]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountCustomJwtInput {
         pub custom_user_id: LinkedAccountCustomJwtInputCustomUserId,
         #[serde(rename = "type")]
@@ -29108,13 +29049,11 @@ pub mod types {
     #[doc = "      \"type\": \"string\","]
     #[doc = "      \"pattern\": \"^(?!discord|everyone|here)[0-9a-zA-Z_.]{2,32}(?:#(?:[0-9]{4}|0))?$\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountDiscordInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub email: ::std::option::Option<::std::string::String>,
@@ -30806,13 +30745,11 @@ pub mod types {
     #[doc = "      \"type\": \"string\","]
     #[doc = "      \"maxLength\": 256"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountFarcasterInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub bio: ::std::option::Option<LinkedAccountFarcasterInputBio>,
@@ -31392,13 +31329,11 @@ pub mod types {
     #[doc = "      \"maxLength\": 39,"]
     #[doc = "      \"pattern\": \"^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountGithubInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub email: ::std::option::Option<::std::string::String>,
@@ -31830,13 +31765,11 @@ pub mod types {
     #[doc = "        \"google_oauth\""]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountGoogleInput {
         pub email: ::std::string::String,
         pub name: ::std::string::String,
@@ -32341,13 +32274,11 @@ pub mod types {
     #[doc = "      \"type\": \"string\","]
     #[doc = "      \"pattern\": \"^(?!instagram|everyone|here)[0-9a-zA-Z._]{2,32}$\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountInstagramInput {
         pub subject: LinkedAccountInstagramInputSubject,
         #[serde(rename = "type")]
@@ -32767,13 +32698,11 @@ pub mod types {
     #[doc = "        \"line_oauth\""]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountLineInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub email: ::std::option::Option<::std::string::String>,
@@ -33203,13 +33132,11 @@ pub mod types {
     #[doc = "    \"vanityName\": {"]
     #[doc = "      \"type\": \"string\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountLinkedInInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub email: ::std::option::Option<::std::string::String>,
@@ -35123,13 +35050,11 @@ pub mod types {
     #[doc = "        \"spotify_oauth\""]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountSpotifyInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub email: ::std::option::Option<::std::string::String>,
@@ -35492,13 +35417,11 @@ pub mod types {
     #[doc = "      \"type\": \"string\","]
     #[doc = "      \"maxLength\": 255"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountTelegramInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub first_name: ::std::option::Option<LinkedAccountTelegramInputFirstName>,
@@ -36077,13 +36000,11 @@ pub mod types {
     #[doc = "      \"type\": \"string\","]
     #[doc = "      \"pattern\": \"^(?!tiktok|everyone|here)[0-9a-zA-Z]{2,32}$\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountTiktokInput {
         pub name: ::std::option::Option<LinkedAccountTiktokInputName>,
         pub subject: LinkedAccountTiktokInputSubject,
@@ -36585,13 +36506,11 @@ pub mod types {
     #[doc = "      \"type\": \"string\","]
     #[doc = "      \"pattern\": \"^[0-9a-zA-Z|\\\\_]{1,15}$\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct LinkedAccountTwitterInput {
         pub name: LinkedAccountTwitterInputName,
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -40341,13 +40260,11 @@ pub mod types {
     #[doc = "        \"1.0\""]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct Policy {
         pub chain_type: PolicyChainType,
         pub created_at: f64,
@@ -41031,13 +40948,11 @@ pub mod types {
     #[doc = "      \"type\": \"string\","]
     #[doc = "      \"maxLength\": 50"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct PolicyRuleRequestBody {
         pub action: PolicyAction,
         pub conditions: ::std::vec::Vec<PolicyCondition>,
@@ -41313,7 +41228,7 @@ pub mod types {
                 })
         }
     }
-    #[doc = "`PolicyRuleResponse`"]
+    #[doc = "A rule that defines the conditions and action to take if the conditions are true."]
     #[doc = r""]
     #[doc = r" <details><summary>JSON schema</summary>"]
     #[doc = r""]
@@ -41350,30 +41265,96 @@ pub mod types {
     #[doc = "        \"id\": {"]
     #[doc = "          \"type\": \"string\""]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
     #[doc = "  ]"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
-    #[derive(
-        :: serde :: Deserialize,
-        :: serde :: Serialize,
-        Clone,
-        Copy,
-        Debug,
-        Eq,
-        Hash,
-        Ord,
-        PartialEq,
-        PartialOrd,
-    )]
-    #[serde(deny_unknown_fields)]
-    pub enum PolicyRuleResponse {}
-    impl ::std::convert::From<&Self> for PolicyRuleResponse {
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    pub struct PolicyRuleResponse {
+        pub action: PolicyAction,
+        pub conditions: ::std::vec::Vec<PolicyCondition>,
+        pub id: ::std::string::String,
+        pub method: PolicyMethod,
+        pub name: PolicyRuleResponseName,
+    }
+    impl ::std::convert::From<&PolicyRuleResponse> for PolicyRuleResponse {
         fn from(value: &PolicyRuleResponse) -> Self {
             value.clone()
+        }
+    }
+    #[doc = "`PolicyRuleResponseName`"]
+    #[doc = r""]
+    #[doc = r" <details><summary>JSON schema</summary>"]
+    #[doc = r""]
+    #[doc = r" ```json"]
+    #[doc = "{"]
+    #[doc = "  \"type\": \"string\","]
+    #[doc = "  \"maxLength\": 50"]
+    #[doc = "}"]
+    #[doc = r" ```"]
+    #[doc = r" </details>"]
+    #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct PolicyRuleResponseName(::std::string::String);
+    impl ::std::ops::Deref for PolicyRuleResponseName {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<PolicyRuleResponseName> for ::std::string::String {
+        fn from(value: PolicyRuleResponseName) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<&PolicyRuleResponseName> for PolicyRuleResponseName {
+        fn from(value: &PolicyRuleResponseName) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr for PolicyRuleResponseName {
+        type Err = self::error::ConversionError;
+        fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+            if value.chars().count() > 50usize {
+                return Err("longer than 50 characters".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for PolicyRuleResponseName {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String> for PolicyRuleResponseName {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String> for PolicyRuleResponseName {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for PolicyRuleResponseName {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
         }
     }
     #[doc = "Version of the policy. Currently, 1.0 is the only version."]
@@ -41729,13 +41710,11 @@ pub mod types {
     #[doc = "        }"]
     #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct RawSign {
         pub params: RawSignParams,
     }
@@ -41806,13 +41785,11 @@ pub mod types {
     #[doc = "        }"]
     #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct RawSignResponse {
         pub data: RawSignResponseData,
     }
@@ -42457,19 +42434,16 @@ pub mod types {
     #[doc = "        \"transaction\": {"]
     #[doc = "          \"type\": \"string\""]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    },"]
     #[doc = "    \"sponsor\": {"]
     #[doc = "      \"type\": \"boolean\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct SolanaSignAndSendTransactionRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -42740,13 +42714,11 @@ pub mod types {
     #[doc = "    \"transaction\": {"]
     #[doc = "      \"type\": \"string\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct SolanaSignAndSendTransactionRpcInputParams {
         pub encoding: SolanaSignAndSendTransactionRpcInputParamsEncoding,
         pub transaction: ::std::string::String,
@@ -43133,16 +43105,13 @@ pub mod types {
     #[doc = "        \"message\": {"]
     #[doc = "          \"type\": \"string\""]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct SolanaSignMessageRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -43321,13 +43290,11 @@ pub mod types {
     #[doc = "    \"message\": {"]
     #[doc = "      \"type\": \"string\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct SolanaSignMessageRpcInputParams {
         pub encoding: SolanaSignMessageRpcInputParamsEncoding,
         pub message: ::std::string::String,
@@ -43681,16 +43648,13 @@ pub mod types {
     #[doc = "        \"transaction\": {"]
     #[doc = "          \"type\": \"string\""]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct SolanaSignTransactionRpcInput {
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
         pub address: ::std::option::Option<::std::string::String>,
@@ -43869,13 +43833,11 @@ pub mod types {
     #[doc = "    \"transaction\": {"]
     #[doc = "      \"type\": \"string\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct SolanaSignTransactionRpcInputParams {
         pub encoding: SolanaSignTransactionRpcInputParamsEncoding,
         pub transaction: ::std::string::String,
@@ -45692,13 +45654,11 @@ pub mod types {
     #[doc = "        \"$ref\": \"#/components/schemas/PolicyRuleRequestBody\""]
     #[doc = "      }"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct UpdatePolicyBody {
         #[doc = "Name to assign to policy."]
         #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -45989,23 +45949,90 @@ pub mod types {
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
-    #[derive(
-        :: serde :: Deserialize,
-        :: serde :: Serialize,
-        Clone,
-        Copy,
-        Debug,
-        Eq,
-        Hash,
-        Ord,
-        PartialEq,
-        PartialOrd,
-    )]
-    #[serde(deny_unknown_fields)]
-    pub enum UpdatePolicyRuleResponse {}
-    impl ::std::convert::From<&Self> for UpdatePolicyRuleResponse {
+    #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
+    pub struct UpdatePolicyRuleResponse {
+        pub action: PolicyAction,
+        pub conditions: ::std::vec::Vec<PolicyCondition>,
+        pub id: ::std::string::String,
+        pub method: PolicyMethod,
+        pub name: UpdatePolicyRuleResponseName,
+    }
+    impl ::std::convert::From<&UpdatePolicyRuleResponse> for UpdatePolicyRuleResponse {
         fn from(value: &UpdatePolicyRuleResponse) -> Self {
             value.clone()
+        }
+    }
+    #[doc = "`UpdatePolicyRuleResponseName`"]
+    #[doc = r""]
+    #[doc = r" <details><summary>JSON schema</summary>"]
+    #[doc = r""]
+    #[doc = r" ```json"]
+    #[doc = "{"]
+    #[doc = "  \"type\": \"string\","]
+    #[doc = "  \"maxLength\": 50"]
+    #[doc = "}"]
+    #[doc = r" ```"]
+    #[doc = r" </details>"]
+    #[derive(:: serde :: Serialize, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[serde(transparent)]
+    pub struct UpdatePolicyRuleResponseName(::std::string::String);
+    impl ::std::ops::Deref for UpdatePolicyRuleResponseName {
+        type Target = ::std::string::String;
+        fn deref(&self) -> &::std::string::String {
+            &self.0
+        }
+    }
+    impl ::std::convert::From<UpdatePolicyRuleResponseName> for ::std::string::String {
+        fn from(value: UpdatePolicyRuleResponseName) -> Self {
+            value.0
+        }
+    }
+    impl ::std::convert::From<&UpdatePolicyRuleResponseName> for UpdatePolicyRuleResponseName {
+        fn from(value: &UpdatePolicyRuleResponseName) -> Self {
+            value.clone()
+        }
+    }
+    impl ::std::str::FromStr for UpdatePolicyRuleResponseName {
+        type Err = self::error::ConversionError;
+        fn from_str(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+            if value.chars().count() > 50usize {
+                return Err("longer than 50 characters".into());
+            }
+            Ok(Self(value.to_string()))
+        }
+    }
+    impl ::std::convert::TryFrom<&str> for UpdatePolicyRuleResponseName {
+        type Error = self::error::ConversionError;
+        fn try_from(value: &str) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<&::std::string::String> for UpdatePolicyRuleResponseName {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: &::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl ::std::convert::TryFrom<::std::string::String> for UpdatePolicyRuleResponseName {
+        type Error = self::error::ConversionError;
+        fn try_from(
+            value: ::std::string::String,
+        ) -> ::std::result::Result<Self, self::error::ConversionError> {
+            value.parse()
+        }
+    }
+    impl<'de> ::serde::Deserialize<'de> for UpdatePolicyRuleResponseName {
+        fn deserialize<D>(deserializer: D) -> ::std::result::Result<Self, D::Error>
+        where
+            D: ::serde::Deserializer<'de>,
+        {
+            ::std::string::String::deserialize(deserializer)?
+                .parse()
+                .map_err(|e: self::error::ConversionError| {
+                    <D::Error as ::serde::de::Error>::custom(e.to_string())
+                })
         }
     }
     #[doc = "`UpdatePolicyRuleRuleId`"]
@@ -55635,8 +55662,7 @@ pub mod types {
     #[doc = "          \"signer_id\": {"]
     #[doc = "            \"type\": \"string\""]
     #[doc = "          }"]
-    #[doc = "        },"]
-    #[doc = "        \"additionalProperties\": false"]
+    #[doc = "        }"]
     #[doc = "      }"]
     #[doc = "    },"]
     #[doc = "    \"owner\": {"]
@@ -55650,8 +55676,7 @@ pub mod types {
     #[doc = "            \"user_id\": {"]
     #[doc = "              \"type\": \"string\""]
     #[doc = "            }"]
-    #[doc = "          },"]
-    #[doc = "          \"additionalProperties\": false"]
+    #[doc = "          }"]
     #[doc = "        },"]
     #[doc = "        {"]
     #[doc = "          \"type\": \"object\","]
@@ -55662,8 +55687,7 @@ pub mod types {
     #[doc = "            \"public_key\": {"]
     #[doc = "              \"type\": \"string\""]
     #[doc = "            }"]
-    #[doc = "          },"]
-    #[doc = "          \"additionalProperties\": false"]
+    #[doc = "          }"]
     #[doc = "        },"]
     #[doc = "        {},"]
     #[doc = "        {}"]
@@ -55692,13 +55716,11 @@ pub mod types {
     #[doc = "        }"]
     #[doc = "      ]"]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct WalletImportSubmissionRequest {
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub additional_signers: ::std::vec::Vec<WalletImportSubmissionRequestAdditionalSignersItem>,
@@ -55736,13 +55758,11 @@ pub mod types {
     #[doc = "    \"signer_id\": {"]
     #[doc = "      \"type\": \"string\""]
     #[doc = "    }"]
-    #[doc = "  },"]
-    #[doc = "  \"additionalProperties\": false"]
+    #[doc = "  }"]
     #[doc = "}"]
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(deny_unknown_fields)]
     pub struct WalletImportSubmissionRequestAdditionalSignersItem {
         #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
         pub override_policy_ids: ::std::vec::Vec<::std::string::String>,
@@ -55771,8 +55791,7 @@ pub mod types {
     #[doc = "        \"user_id\": {"]
     #[doc = "          \"type\": \"string\""]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    },"]
     #[doc = "    {"]
     #[doc = "      \"type\": \"object\","]
@@ -55783,8 +55802,7 @@ pub mod types {
     #[doc = "        \"public_key\": {"]
     #[doc = "          \"type\": \"string\""]
     #[doc = "        }"]
-    #[doc = "      },"]
-    #[doc = "      \"additionalProperties\": false"]
+    #[doc = "      }"]
     #[doc = "    },"]
     #[doc = "    {},"]
     #[doc = "    {}"]
@@ -55793,7 +55811,7 @@ pub mod types {
     #[doc = r" ```"]
     #[doc = r" </details>"]
     #[derive(:: serde :: Deserialize, :: serde :: Serialize, Clone, Debug)]
-    #[serde(untagged, deny_unknown_fields)]
+    #[serde(untagged)]
     pub enum WalletImportSubmissionRequestOwner {
         Variant0 { user_id: ::std::string::String },
         Variant1 { public_key: ::std::string::String },

--- a/openapi.json
+++ b/openapi.json
@@ -243,8 +243,7 @@
             "required": [
               "message",
               "encoding"
-            ],
-            "additionalProperties": false
+            ]
           },
           "address": {
             "type": "string"
@@ -259,8 +258,7 @@
         "required": [
           "method",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "EthereumSignTransactionRpcInput": {
         "type": "object",
@@ -392,14 +390,12 @@
                       }
                     ]
                   }
-                },
-                "additionalProperties": false
+                }
               }
             },
             "required": [
               "transaction"
-            ],
-            "additionalProperties": false
+            ]
           },
           "address": {
             "type": "string"
@@ -414,8 +410,7 @@
         "required": [
           "method",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "EthereumSendTransactionRpcInput": {
         "type": "object",
@@ -551,14 +546,12 @@
                       }
                     ]
                   }
-                },
-                "additionalProperties": false
+                }
               }
             },
             "required": [
               "transaction"
-            ],
-            "additionalProperties": false
+            ]
           },
           "sponsor": {
             "type": "boolean"
@@ -577,8 +570,7 @@
           "method",
           "caip2",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "EthereumSignTypedDataRpcInput": {
         "type": "object",
@@ -637,14 +629,12 @@
                   "types",
                   "message",
                   "primary_type"
-                ],
-                "additionalProperties": false
+                ]
               }
             },
             "required": [
               "typed_data"
-            ],
-            "additionalProperties": false
+            ]
           },
           "address": {
             "type": "string"
@@ -659,8 +649,7 @@
         "required": [
           "method",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "EthereumSign7702AuthorizationRpcInput": {
         "type": "object",
@@ -705,8 +694,7 @@
             "required": [
               "contract",
               "chain_id"
-            ],
-            "additionalProperties": false
+            ]
           },
           "address": {
             "type": "string"
@@ -721,8 +709,7 @@
         "required": [
           "method",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "EthereumSecp256k1SignRpcInput": {
         "type": "object",
@@ -742,8 +729,7 @@
             },
             "required": [
               "hash"
-            ],
-            "additionalProperties": false
+            ]
           },
           "address": {
             "type": "string"
@@ -758,8 +744,7 @@
         "required": [
           "method",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "SolanaSignTransactionRpcInput": {
         "type": "object",
@@ -786,8 +771,7 @@
             "required": [
               "transaction",
               "encoding"
-            ],
-            "additionalProperties": false
+            ]
           },
           "address": {
             "type": "string"
@@ -802,8 +786,7 @@
         "required": [
           "method",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "SolanaSignAndSendTransactionRpcInput": {
         "type": "object",
@@ -834,8 +817,7 @@
             "required": [
               "transaction",
               "encoding"
-            ],
-            "additionalProperties": false
+            ]
           },
           "sponsor": {
             "type": "boolean"
@@ -854,8 +836,7 @@
           "method",
           "caip2",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "SolanaSignMessageRpcInput": {
         "type": "object",
@@ -882,8 +863,7 @@
             "required": [
               "message",
               "encoding"
-            ],
-            "additionalProperties": false
+            ]
           },
           "address": {
             "type": "string"
@@ -898,8 +878,7 @@
         "required": [
           "method",
           "params"
-        ],
-        "additionalProperties": false
+        ]
       },
       "EthereumSignTransactionRpcResponse": {
         "type": "object",
@@ -1074,8 +1053,7 @@
                       }
                     ]
                   }
-                },
-                "additionalProperties": false
+                }
               }
             },
             "required": [
@@ -1399,8 +1377,7 @@
         },
         "required": [
           "data"
-        ],
-        "additionalProperties": false
+        ]
       },
       "PrivateKeyInitInput": {
         "type": "object",
@@ -3385,7 +3362,6 @@
           "email",
           "name"
         ],
-        "additionalProperties": false,
         "title": "Google"
       },
       "LinkedAccountTwitterInput": {
@@ -3421,7 +3397,6 @@
           "name",
           "username"
         ],
-        "additionalProperties": false,
         "title": "Twitter"
       },
       "LinkedAccountDiscordInput": {
@@ -3451,7 +3426,6 @@
           "subject",
           "username"
         ],
-        "additionalProperties": false,
         "title": "Discord"
       },
       "LinkedAccountGithubInput": {
@@ -3485,7 +3459,6 @@
           "subject",
           "username"
         ],
-        "additionalProperties": false,
         "title": "Github"
       },
       "LinkedAccountSpotifyInput": {
@@ -3512,7 +3485,6 @@
           "type",
           "subject"
         ],
-        "additionalProperties": false,
         "title": "Spotify"
       },
       "LinkedAccountInstagramInput": {
@@ -3538,7 +3510,6 @@
           "subject",
           "username"
         ],
-        "additionalProperties": false,
         "title": "Instagram"
       },
       "LinkedAccountTiktokInput": {
@@ -3571,7 +3542,6 @@
           "username",
           "name"
         ],
-        "additionalProperties": false,
         "title": "Tiktok"
       },
       "LinkedAccountLineInput": {
@@ -3605,7 +3575,6 @@
           "type",
           "subject"
         ],
-        "additionalProperties": false,
         "title": "LINE"
       },
       "LinkedAccountAppleInput": {
@@ -3630,7 +3599,6 @@
           "type",
           "subject"
         ],
-        "additionalProperties": false,
         "title": "Apple"
       },
       "LinkedAccountLinkedInInput": {
@@ -3661,7 +3629,6 @@
           "type",
           "subject"
         ],
-        "additionalProperties": false,
         "title": "LinkedIn"
       },
       "LinkedAccountFarcasterInput": {
@@ -3705,7 +3672,6 @@
           "fid",
           "owner_address"
         ],
-        "additionalProperties": false,
         "title": "Farcaster"
       },
       "LinkedAccountTelegramInput": {
@@ -3743,7 +3709,6 @@
           "type",
           "telegram_user_id"
         ],
-        "additionalProperties": false,
         "title": "Telegram"
       },
       "LinkedAccountCustomJWTInput": {
@@ -3765,7 +3730,6 @@
           "type",
           "custom_user_id"
         ],
-        "additionalProperties": false,
         "title": "Custom JWT"
       },
       "LinkedAccountInput": {
@@ -4310,7 +4274,6 @@
           "conditions",
           "action"
         ],
-        "additionalProperties": false,
         "description": "The rules that apply to each method the policy covers.",
         "title": "PolicyRuleRequestBody"
       },
@@ -4328,8 +4291,7 @@
             },
             "required": [
               "id"
-            ],
-            "additionalProperties": false
+            ]
           }
         ],
         "description": "A rule that defines the conditions and action to take if the conditions are true.",
@@ -4432,7 +4394,6 @@
           "created_at",
           "rules"
         ],
-        "additionalProperties": false,
         "example": {
           "id": "tb54eps4z44ed0jepousxi4n",
           "name": "Allowlisted stablecoins",
@@ -5893,7 +5854,6 @@
                 "required": [
                   "params"
                 ],
-                "additionalProperties": false,
                 "title": "raw_sign",
                 "example": {
                   "params": {
@@ -6754,8 +6714,7 @@
                       },
                       "required": [
                         "signer_id"
-                      ],
-                      "additionalProperties": false
+                      ]
                     }
                   },
                   "owner": {
@@ -6769,8 +6728,7 @@
                         },
                         "required": [
                           "user_id"
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       {
                         "type": "object",
@@ -6781,8 +6739,7 @@
                         },
                         "required": [
                           "public_key"
-                        ],
-                        "additionalProperties": false
+                        ]
                       },
                       {
                         "nullable": true
@@ -6800,7 +6757,6 @@
                 "required": [
                   "wallet"
                 ],
-                "additionalProperties": false,
                 "title": "Wallet import submission request",
                 "example": {
                   "wallet": {
@@ -7903,8 +7859,7 @@
                             },
                             "required": [
                               "signer_id"
-                            ],
-                            "additionalProperties": false
+                            ]
                           }
                         },
                         "policy_ids": {
@@ -7937,8 +7892,7 @@
                       },
                       "required": [
                         "chain_type"
-                      ],
-                      "additionalProperties": false
+                      ]
                     }
                   }
                 },
@@ -8178,8 +8132,7 @@
                   "name",
                   "chain_type",
                   "rules"
-                ],
-                "additionalProperties": false
+                ]
               }
             }
           }
@@ -8301,8 +8254,7 @@
                       }
                     ]
                   }
-                },
-                "additionalProperties": false
+                }
               }
             }
           }

--- a/scripts/openapi.jq
+++ b/scripts/openapi.jq
@@ -8,4 +8,10 @@
   then null
   else .
   end
+) | walk(
+  # we use additionalProperties inappropriate almost everywhere so just remove it
+  if type == "object" and .additionalProperties == false
+  then del(.additionalProperties)
+  else .
+  end
 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,3 +35,17 @@ pub(crate) fn get_auth_header(app_id: &str, app_secret: &str) -> String {
     let credentials = format!("{app_id}:{app_secret}");
     format!("Basic {}", STANDARD.encode(credentials))
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn deserialize() {
+        let body = r#"{"id":"kra9fvbs9vo47ge1xs5x97k5","name":"test-policy-1757686660","chain_type":"solana","rules":[{"name":"test-rule","method":"signTransaction","conditions":[{"field_source":"solana_system_program_instruction","field":"Transfer.lamports","operator":"lt","value":"1000000"}],"action":"ALLOW","id":"h7ugroh0uaotl5khnc8xftdo"}],"version":"1.0","created_at":1757686660877,"owner_id":null}"#;
+
+        let jd = &mut serde_json::Deserializer::from_str(body);
+        let result: Result<super::generated::types::Policy, _> =
+            serde_path_to_error::deserialize(jd);
+
+        println!("{:?}", result.unwrap());
+    }
+}

--- a/tests/policies.rs
+++ b/tests/policies.rs
@@ -1,31 +1,312 @@
-#[tokio::test]
-#[ignore]
-async fn test_policies_create() {}
+use std::str::FromStr;
+
+use anyhow::Result;
+use privy_rs::{AuthorizationContext, IntoKey, PrivateKey, generated::types::*};
+
+mod common;
 
 #[tokio::test]
-#[ignore]
-async fn test_policies_get() {}
+async fn test_policies_create() -> Result<()> {
+    let client = common::get_test_client()?;
+
+    let unique_name = format!("test-policy-{}", chrono::Utc::now().timestamp());
+    let policy_body = CreatePolicyBody {
+        chain_type: PolicyChainType::Solana,
+        name: CreatePolicyBodyName::try_from(unique_name).unwrap(),
+        owner: None,
+        owner_id: None,
+        rules: vec![PolicyRuleRequestBody {
+            action: PolicyAction::Allow,
+            conditions: vec![PolicyCondition::SolanaSystemProgramInstructionCondition(
+                SolanaSystemProgramInstructionCondition {
+                    field: SolanaSystemProgramInstructionConditionField::TransferLamports,
+                    field_source: SolanaSystemProgramInstructionConditionFieldSource::SolanaSystemProgramInstruction,
+                    operator: ConditionOperator::Lt,
+                    value: ConditionValue::String("1000000".to_string()),
+                }
+            )],
+            method: PolicyMethod::SignTransaction,
+            name: PolicyRuleRequestBodyName::try_from("test-rule").unwrap(),
+        }],
+        version: CreatePolicyBodyVersion::try_from("1.0").unwrap(),
+    };
+
+    let result = debug_response!(client.policies().create(None, &policy_body)).await?;
+
+    println!("Created policy: {:?}", result);
+    assert!(result.into_inner().id.len() == 24);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_policies_get_rule() {}
+async fn test_policies_get() -> Result<()> {
+    let client = common::get_test_client()?;
+    let policy = common::ensure_test_policy(&client, vec![]).await.unwrap();
+
+    let result = client
+        .policies()
+        .get(&GetPolicyPolicyId::try_from(&*policy.id).unwrap())
+        .await;
+    assert!(result.is_ok(), "Failed to get policy: {:?}", result);
+
+    let policy_response = result.unwrap();
+    println!("Retrieved policy: {:?}", policy_response);
+    assert_eq!(policy_response.into_inner().id, policy.id);
+
+    Ok(())
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_policies_update_with_auth_context() {}
+async fn test_policies_get_rule() {
+    let client = common::get_test_client().unwrap();
+    let policy = common::ensure_test_policy(&client, vec![
+        PolicyRuleRequestBody {
+            action: PolicyAction::Allow,
+            conditions: vec![PolicyCondition::SolanaSystemProgramInstructionCondition(
+                SolanaSystemProgramInstructionCondition {
+                    field: SolanaSystemProgramInstructionConditionField::TransferLamports,
+                    field_source: SolanaSystemProgramInstructionConditionFieldSource::SolanaSystemProgramInstruction,
+                    operator: ConditionOperator::Lt,
+                    value: ConditionValue::String("2000000".to_string()),
+                }
+            )],
+
+            method: PolicyMethod::SignTransaction,
+            name: PolicyRuleRequestBodyName::try_from("updated-rule").unwrap(),
+        }
+    ]).await.unwrap();
+
+    let policy_id = GetPolicyRulePolicyId::try_from(&*policy.id).unwrap();
+    let rule_id = GetPolicyRuleRuleId::try_from(&*policy.rules.first().unwrap().id).unwrap();
+
+    let result = client.policies().get_rule(&policy_id, &rule_id).await;
+    assert!(result.is_ok(), "Failed to get policy rule: {:?}", result);
+
+    let rule_response = result.unwrap();
+    println!("Retrieved policy rule: {:?}", rule_response);
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_policies_delete() {}
+async fn test_policies_update_with_auth_context() {
+    let client = common::get_test_client().unwrap();
+
+    let private_key = include_str!("./test_private_key.pem");
+    let key = PrivateKey(private_key.into());
+    let pubkey = key.get_key().await.unwrap().public_key();
+
+    let policy = common::ensure_test_policy_with_user(
+        &client,
+        vec![],
+        Some(OwnerInput::PublicKey(pubkey.to_string())),
+    )
+    .await
+    .unwrap();
+
+    let ctx = AuthorizationContext::new();
+    ctx.push(key);
+
+    let update_body = UpdatePolicyBody {
+        owner: Some(OwnerInput::PublicKey(pubkey.to_string())),
+        owner_id: None,
+        name: Some(UpdatePolicyBodyName::try_from("my-owned-policy").unwrap()),
+        rules: vec![PolicyRuleRequestBody {
+            action: PolicyAction::Allow,
+            conditions: vec![PolicyCondition::SolanaSystemProgramInstructionCondition(
+                SolanaSystemProgramInstructionCondition {
+                    field: SolanaSystemProgramInstructionConditionField::TransferLamports,
+                    field_source: SolanaSystemProgramInstructionConditionFieldSource::SolanaSystemProgramInstruction,
+                    operator: ConditionOperator::Lt,
+                    value: ConditionValue::String("2000000".to_string()),
+                }
+            )],
+
+            method: PolicyMethod::SignTransaction,
+            name: PolicyRuleRequestBodyName::try_from("updated-rule").unwrap(),
+        }],
+    };
+
+    let policy_id = UpdatePolicyPolicyId::try_from(&*policy.id).unwrap();
+
+    let result = client
+        .policies()
+        .update(&policy_id, &ctx, &update_body)
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "Failed to update policy with auth context: {:?}",
+        result
+    );
+
+    let policy_response = result.unwrap();
+    println!("Updated policy: {:?}", policy_response);
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_policies_create_rule() {}
+async fn test_policies_delete() {
+    let client = common::get_test_client().unwrap();
+
+    let ctx = AuthorizationContext::new();
+
+    let private_key = include_str!("./test_private_key.pem");
+    ctx.push(PrivateKey(private_key.into()));
+
+    // First create a policy to delete
+    let unique_name = format!("delete-policy-{}", chrono::Utc::now().timestamp());
+    let policy_body = CreatePolicyBody {
+        chain_type: PolicyChainType::Solana,
+        name: CreatePolicyBodyName::try_from(unique_name).unwrap(),
+        // TODO: set the owner here once we have a JWT
+        owner: None,
+        owner_id: None,
+        rules: vec![PolicyRuleRequestBody {
+            action: PolicyAction::Allow,
+            conditions: vec![PolicyCondition::SolanaSystemProgramInstructionCondition(
+                SolanaSystemProgramInstructionCondition {
+                    field: SolanaSystemProgramInstructionConditionField::TransferLamports,
+                    field_source: SolanaSystemProgramInstructionConditionFieldSource::SolanaSystemProgramInstruction,
+                    operator: ConditionOperator::Lt,
+                    value: ConditionValue::String("1000000".to_string()),
+                }
+            )],
+            method: PolicyMethod::SignTransaction,
+            name: PolicyRuleRequestBodyName::try_from("test-rule").unwrap(),
+        }],
+        version: CreatePolicyBodyVersion::try_from("1.0").unwrap(),
+    };
+
+    let create_result = client.policies().create(None, &policy_body).await.unwrap();
+    let policy_id = create_result.into_inner().id;
+
+    // Now delete the policy
+    let result = client
+        .policies()
+        .delete(
+            &DeletePolicyPolicyId::try_from(policy_id.as_str()).unwrap(),
+            &ctx,
+        )
+        .await;
+    assert!(result.is_ok(), "Failed to delete policy: {:?}", result);
+
+    let delete_response = result.unwrap();
+    println!("Deleted policy response: {:?}", delete_response);
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_policies_update_rule() {}
+async fn test_policies_create_rule() {
+    let client = common::get_test_client().unwrap();
+    let policy = common::ensure_test_policy(&client, vec![]).await.unwrap();
+
+    let ctx = AuthorizationContext::new();
+
+    let private_key = include_str!("./test_private_key.pem");
+    ctx.push(PrivateKey(private_key.into()));
+
+    let unique_rule_name = format!("test-rule-{}", chrono::Utc::now().timestamp());
+    let rule = PolicyRuleRequestBody {
+        action: PolicyAction::Allow,
+        conditions: vec![PolicyCondition::SolanaSystemProgramInstructionCondition(
+            SolanaSystemProgramInstructionCondition {
+                field: SolanaSystemProgramInstructionConditionField::TransferLamports,
+                field_source: SolanaSystemProgramInstructionConditionFieldSource::SolanaSystemProgramInstruction,
+                operator: ConditionOperator::Lt,
+                value: ConditionValue::String("5000000".to_string()),
+            }
+        )],
+        method: PolicyMethod::SignTransaction,
+        name: PolicyRuleRequestBodyName::try_from(unique_rule_name).unwrap(),
+    };
+
+    let result = client
+        .policies()
+        .create_rule(
+            &CreatePolicyRulePolicyId::from_str(&*policy.id).unwrap(),
+            &ctx,
+            &rule,
+        )
+        .await;
+    assert!(result.is_ok(), "Failed to create policy rule: {:?}", result);
+
+    let rule_response = result.unwrap();
+    println!("Created policy rule: {:?}", rule_response);
+}
 
 #[tokio::test]
-#[ignore]
-async fn test_policies_delete_rule() {}
+async fn test_policies_update_rule() {
+    let client = common::get_test_client().unwrap();
+
+    let mut rule = PolicyRuleRequestBody {
+        action: PolicyAction::Deny,
+        conditions: vec![PolicyCondition::SolanaSystemProgramInstructionCondition(
+            SolanaSystemProgramInstructionCondition {
+                field: SolanaSystemProgramInstructionConditionField::TransferLamports,
+                field_source: SolanaSystemProgramInstructionConditionFieldSource::SolanaSystemProgramInstruction,
+                operator: ConditionOperator::Gt,
+                value: ConditionValue::String("10000000".to_string()),
+            }
+        )],
+        method: PolicyMethod::SignTransaction,
+        name: PolicyRuleRequestBodyName::try_from("my-great-rule").unwrap(),
+    };
+
+    let policy = common::ensure_test_policy(&client, vec![rule.clone()])
+        .await
+        .unwrap();
+
+    rule.action = PolicyAction::Allow;
+
+    let ctx = AuthorizationContext::new();
+    let private_key = include_str!("./test_private_key.pem");
+    ctx.push(PrivateKey(private_key.into()));
+
+    let result = client
+        .policies()
+        .update_rule(
+            &UpdatePolicyRulePolicyId::try_from(&*policy.id).unwrap(),
+            &UpdatePolicyRuleRuleId::try_from(&*policy.rules.first().unwrap().id).unwrap(),
+            &ctx,
+            &rule,
+        )
+        .await;
+    assert!(result.is_ok(), "Failed to update policy rule: {:?}", result);
+
+    let rule_response = result.unwrap();
+    println!("Updated policy rule: {:?}", rule_response);
+}
+
+#[tokio::test]
+async fn test_policies_delete_rule() {
+    let client = common::get_test_client().unwrap();
+    let policy = common::ensure_test_policy(&client, vec![PolicyRuleRequestBody {
+        action: PolicyAction::Allow,
+        conditions: vec![PolicyCondition::SolanaSystemProgramInstructionCondition(
+            SolanaSystemProgramInstructionCondition {
+                field: SolanaSystemProgramInstructionConditionField::TransferLamports,
+                field_source: SolanaSystemProgramInstructionConditionFieldSource::SolanaSystemProgramInstruction,
+                operator: ConditionOperator::Lt,
+                value: ConditionValue::String("1000000".to_string()),
+            }
+        )],
+        method: PolicyMethod::SignTransaction,
+        name: PolicyRuleRequestBodyName::try_from("my-unique-rule").unwrap(),
+    }]).await.unwrap();
+
+    let ctx = AuthorizationContext::new();
+
+    let private_key = include_str!("./test_private_key.pem");
+    ctx.push(PrivateKey(private_key.into()));
+
+    let policy_id = DeletePolicyRulePolicyId::try_from(&*policy.id).unwrap();
+    let rule_id = DeletePolicyRuleRuleId::try_from(&*policy.rules.first().unwrap().id).unwrap();
+
+    let result = client
+        .policies()
+        .delete_rule(&policy_id, &rule_id, &ctx)
+        .await;
+
+    assert!(result.is_ok(), "Failed to delete policy rule: {:?}", result);
+
+    let delete_response = result.unwrap();
+    println!("Deleted policy rule response: {:?}", delete_response);
+}


### PR DESCRIPTION
~Blocked on an issue in progenitor which can't handle~

Actually a problem on our end. I have update the JQ script to explain. We could override this in the places it actually causes problems but I don't want us to have to keep updating the overrides. If we want to re-enable it we need to ensure that unions in jq are handled well.
