### PR TITLE
chore: split out CI and e2e tests and add proper env for them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,18 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, arlyon/next]
+    branches: [main]
   pull_request:
-    branches: [main, arlyon/next]
-
-env:
-  CARGO_TERM_COLOR: always
-  PRIVY_TEST_APP_ID: ${{ secrets.PRIVY_TEST_APP_ID }}
-  PRIVY_TEST_APP_SECRET: ${{ secrets.PRIVY_TEST_APP_SECRET }}
-  PRIVY_TEST_JWT_PRIVATE_KEY: ${{ secrets.PRIVY_TEST_JWT_PRIVATE_KEY }}
-  PRIVY_TEST_URL: ${{ secrets.PRIVY_TEST_URL }}
-  # staging authorization flow is very flaky. we'll remove this eventually
-  MARK_FLAKY_TESTS_RETRIES: 20
+    branches: [main]
 
 jobs:
   test:
@@ -51,7 +42,13 @@ jobs:
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --lib
+
+      - name: Run examples
+        run: cargo test --examples
+
+      - name: Run doc tests
+        run: cargo test --doc
 
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,54 @@
+name: Integration Tests
+
+on:
+  # pull_request_target runs in the context of the base repository (access to secrets).
+  # We combine this with an Environment Gate to make it safe.
+  pull_request_target:
+    branches: ["main"]
+    types: [opened, synchronize, reopened]
+
+  # Allow manual triggering for debugging
+  workflow_dispatch:
+
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+
+    # CRITICAL: This gates the job. It will pause here until a maintainer
+    # manually approves the deployment to 'staging' in the GitHub UI.
+    environment: staging
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # explicitly pull out the exact commit that was approved,
+          # otherwise a well-timed race condition could run a newer commit
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run Integration Tests
+        env:
+          PRIVY_TEST_APP_ID: ${{ secrets.PRIVY_TEST_APP_ID }}
+          PRIVY_TEST_APP_SECRET: ${{ secrets.PRIVY_TEST_APP_SECRET }}
+          PRIVY_TEST_JWT_PRIVATE_KEY: ${{ secrets.PRIVY_TEST_JWT_PRIVATE_KEY }}
+          PRIVY_TEST_URL: ${{ secrets.PRIVY_TEST_URL }}
+          MARK_FLAKY_TESTS_RETRIES: 20
+        # scoped to all tests in the tests folder
+        run: cargo test --test '*'


### PR DESCRIPTION
Needed changes:
- remove CI branch protection for external contributors
- create a new env and add an env protection rule that requires maintainer sign-off
- (optional) add the secrets to the new env and remove them from the repo-wide scope
