### PR TITLE
Add gas sponsorship support to convenience methods

### DIFF
--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -25,6 +25,39 @@ use crate::{
     },
 };
 
+/// Options for sending an Ethereum transaction.
+///
+/// This struct uses `#[non_exhaustive]` to allow new fields to be added in the future
+/// without breaking existing code. Always construct using `..Default::default()`:
+///
+/// ```rust
+/// use privy_rs::ethereum::SendTransactionOptions;
+///
+/// let options = SendTransactionOptions::new().with_sponsor(true);
+/// ```
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct SendTransactionOptions {
+    /// Whether to sponsor (pay for) the gas fees of this transaction.
+    /// - `Some(true)` — enable gas sponsorship
+    /// - `Some(false)` — explicitly disable gas sponsorship
+    /// - `None` — use the server default
+    pub sponsor: Option<bool>,
+}
+
+impl SendTransactionOptions {
+    /// Creates a new `SendTransactionOptions` with all defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the sponsor option.
+    pub fn with_sponsor(mut self, sponsor: bool) -> Self {
+        self.sponsor = Some(sponsor);
+        self
+    }
+}
+
 /// Service for Ethereum-specific wallet operations.
 ///
 /// Provides convenient methods for common Ethereum wallet operations such as:
@@ -548,6 +581,65 @@ impl EthereumService {
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
+        self.send_transaction_with_options(
+            wallet_id,
+            caip2,
+            transaction,
+            authorization_context,
+            idempotency_key,
+            &SendTransactionOptions::default(),
+        )
+        .await
+    }
+
+    /// Signs and sends a transaction with additional options such as gas sponsorship.
+    ///
+    /// This method is identical to [`send_transaction`](Self::send_transaction) but accepts
+    /// a [`SendTransactionOptions`] struct for additional configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use anyhow::Result;
+    /// # async fn example() -> Result<()> {
+    /// use privy_rs::{AuthorizationContext, ethereum::SendTransactionOptions, generated::types::*};
+    /// # use privy_rs::PrivyClient;
+    ///
+    /// # let client = PrivyClient::new("app_id".to_string(), "app_secret".to_string())?;
+    /// let ethereum_service = client.wallets().ethereum();
+    /// let auth_ctx = AuthorizationContext::new();
+    ///
+    /// let transaction = EthereumSendTransactionRpcInputParamsTransaction {
+    ///     to: Some("0x742d35Cc6635C0532925a3b8c17d6d1E9C2F7ca".to_string()),
+    ///     value: None, gas_limit: None, max_fee_per_gas: None,
+    ///     max_priority_fee_per_gas: None, data: None, chain_id: None,
+    ///     from: None, gas_price: None, nonce: None, type_: None,
+    /// };
+    ///
+    /// let options = SendTransactionOptions::new().with_sponsor(true);
+    ///
+    /// let result = ethereum_service
+    ///     .send_transaction_with_options(
+    ///         "wallet_id",
+    ///         "eip155:1",
+    ///         transaction,
+    ///         &auth_ctx,
+    ///         None,
+    ///         &options,
+    ///     )
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn send_transaction_with_options(
+        &self,
+        wallet_id: &str,
+        caip2: &str,
+        transaction: EthereumSendTransactionRpcInputParamsTransaction,
+        authorization_context: &AuthorizationContext,
+        idempotency_key: Option<&str>,
+        options: &SendTransactionOptions,
+    ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
         let rpc_body =
             WalletRpcBody::EthereumSendTransactionRpcInput(EthereumSendTransactionRpcInput {
                 address: None,
@@ -557,7 +649,7 @@ impl EthereumService {
                 chain_type: None,
                 method: EthereumSendTransactionRpcInputMethod::EthSendTransaction,
                 params: EthereumSendTransactionRpcInputParams { transaction },
-                sponsor: Some(false),
+                sponsor: options.sponsor,
             });
 
         self.wallets_client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,10 @@ pub(crate) mod utils;
 
 pub use client::PrivyClient;
 pub use errors::*;
+pub use ethereum::SendTransactionOptions;
 pub use keys::*;
 pub use privy_hpke::PrivyHpke;
+pub use solana::SignAndSendTransactionOptions;
 pub use utils::{
     Method, Utils, WalletApiRequestSignatureInput, format_request_for_authorization_signature,
     generate_authorization_signatures,

--- a/src/solana.rs
+++ b/src/solana.rs
@@ -23,6 +23,39 @@ use crate::{
     },
 };
 
+/// Options for signing and sending a Solana transaction.
+///
+/// This struct uses `#[non_exhaustive]` to allow new fields to be added in the future
+/// without breaking existing code. Always construct using `..Default::default()`:
+///
+/// ```rust
+/// use privy_rs::solana::SignAndSendTransactionOptions;
+///
+/// let options = SignAndSendTransactionOptions::new().with_sponsor(true);
+/// ```
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct SignAndSendTransactionOptions {
+    /// Whether to sponsor (pay for) the transaction fees.
+    /// - `Some(true)` — enable gas sponsorship
+    /// - `Some(false)` — explicitly disable gas sponsorship
+    /// - `None` — use the server default
+    pub sponsor: Option<bool>,
+}
+
+impl SignAndSendTransactionOptions {
+    /// Creates a new `SignAndSendTransactionOptions` with all defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the sponsor option.
+    pub fn with_sponsor(mut self, sponsor: bool) -> Self {
+        self.sponsor = Some(sponsor);
+        self
+    }
+}
+
 /// Service for Solana-specific wallet operations.
 ///
 /// Provides convenient methods for common Solana wallet operations such as:
@@ -291,6 +324,54 @@ impl SolanaService {
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
+        self.sign_and_send_transaction_with_options(
+            wallet_id,
+            caip2,
+            transaction,
+            authorization_context,
+            idempotency_key,
+            &SignAndSendTransactionOptions::default(),
+        )
+        .await
+    }
+
+    /// Signs and sends a Solana transaction with additional options such as gas sponsorship.
+    ///
+    /// This method is identical to [`sign_and_send_transaction`](Self::sign_and_send_transaction)
+    /// but accepts a [`SignAndSendTransactionOptions`] struct for additional configuration.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// use privy_rs::{AuthorizationContext, PrivyClient, solana::SignAndSendTransactionOptions};
+    ///
+    /// let client = PrivyClient::new("app_id".to_string(), "app_secret".to_string())?;
+    /// let solana_service = client.wallets().solana();
+    /// let auth_ctx = AuthorizationContext::new();
+    ///
+    /// let options = SignAndSendTransactionOptions::new().with_sponsor(true);
+    ///
+    /// let result = solana_service.sign_and_send_transaction_with_options(
+    ///     "wallet_id",
+    ///     "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    ///     "base64-encoded-transaction",
+    ///     &auth_ctx,
+    ///     None,
+    ///     &options,
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn sign_and_send_transaction_with_options(
+        &self,
+        wallet_id: &str,
+        caip2: &str,
+        transaction: &str,
+        authorization_context: &AuthorizationContext,
+        idempotency_key: Option<&str>,
+        options: &SignAndSendTransactionOptions,
+    ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
         let caip2_parsed = SolanaSignAndSendTransactionRpcInputCaip2::from_str(caip2)
             .map_err(|_| Error::InvalidRequest("Invalid CAIP-2 format".to_string()))?;
 
@@ -304,7 +385,7 @@ impl SolanaService {
                     encoding: SolanaSignAndSendTransactionRpcInputParamsEncoding::Base64,
                     transaction: transaction.to_string(),
                 },
-                sponsor: Some(false),
+                sponsor: options.sponsor,
             },
         );
 

--- a/tests/wallets.rs
+++ b/tests/wallets.rs
@@ -746,6 +746,120 @@ async fn test_wallets_ethereum_send_transaction() -> Result<()> {
 
 #[tokio::test]
 #[traced_test]
+#[ignore = "ignore tests that attempt to move funds as wallets are not funded"]
+async fn test_wallets_ethereum_send_transaction_with_options_sponsored() -> Result<()> {
+    let client = get_test_client()?;
+
+    let funded_ethereum_wallet_id =
+        std::env::var("FUNDED_ETHEREUM_WALLET_ID").expect("FUNDED_ETHEREUM_WALLET_ID must be set");
+    let funded_ethereum_wallet_address = std::env::var("FUNDED_ETHEREUM_WALLET_ADDRESS")
+        .expect("FUNDED_ETHEREUM_WALLET_ADDRESS must be set");
+    let funded_ethereum_wallet_owner_subject_id = std::env::var("FUNDED_WALLETS_OWNER_SUBJECT_ID")
+        .expect("FUNDED_WALLETS_OWNER_SUBJECT_ID must be set");
+    let recipient_address = std::env::var("ETHEREUM_RECIPIENT_ADDRESS")
+        .expect("ETHEREUM_RECIPIENT_ADDRESS must be set");
+
+    let transaction = EthereumSendTransactionRpcInputParamsTransaction {
+        to: Some(recipient_address),
+        value: Some(EthereumSendTransactionRpcInputParamsTransactionValue::Integer(100)),
+        chain_id: None,
+        from: Some(funded_ethereum_wallet_address.clone()),
+        max_fee_per_gas: None,
+        max_priority_fee_per_gas: None,
+        nonce: None,
+        type_: None,
+        data: Some("0x".to_string()),
+        gas_limit: None,
+        gas_price: None,
+    };
+
+    let options = privy_rs::SendTransactionOptions::new().with_sponsor(true);
+
+    let ctx = AuthorizationContext::new().push(JwtUser(
+        client.clone(),
+        mint_staging_jwt(&funded_ethereum_wallet_owner_subject_id)?,
+    ));
+
+    let result = debug_response!(client.wallets().ethereum().send_transaction_with_options(
+        &funded_ethereum_wallet_id,
+        "eip155:11155111",
+        transaction,
+        &ctx,
+        None,
+        &options,
+    ))
+    .await?;
+
+    println!("Ethereum sponsored transaction sent: {result:?}");
+
+    match result.into_inner() {
+        WalletRpcResponse::EthereumSendTransactionRpcResponse(_) => {}
+        _ => panic!("Expected EthereumSendTransactionRpcResponse"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
+#[ignore = "ignore tests that attempt to move funds as wallets are not funded"]
+async fn test_wallets_solana_sign_and_send_transaction_with_options_sponsored() -> Result<()> {
+    let client = get_test_client()?;
+
+    let funded_solana_wallet_id =
+        std::env::var("FUNDED_SOLANA_WALLET_ID").expect("FUNDED_SOLANA_WALLET_ID must be set");
+    let funded_solana_wallet_address = std::env::var("FUNDED_SOLANA_WALLET_ADDRESS")
+        .expect("FUNDED_SOLANA_WALLET_ADDRESS must be set");
+    let funded_solana_wallet_owner_subject_id =
+        std::env::var("FUNDED_SOLANA_WALLET_OWNER_SUBJECT_ID")
+            .expect("FUNDED_SOLANA_WALLET_OWNER_SUBJECT_ID must be set");
+
+    let from_pubkey = Pubkey::from_str(&funded_solana_wallet_address).unwrap();
+    let to_pubkey = Pubkey::from_str(&funded_solana_wallet_address).unwrap();
+    let lamports = 100;
+
+    let transaction = Transaction::new_with_payer(
+        &[solana_system_interface::instruction::transfer(
+            &from_pubkey,
+            &to_pubkey,
+            lamports,
+        )],
+        None,
+    );
+
+    let transaction = STANDARD.encode(bincode::serialize(&transaction).unwrap());
+
+    let options = privy_rs::SignAndSendTransactionOptions::new().with_sponsor(true);
+
+    let ctx = AuthorizationContext::new().push(JwtUser(
+        client.clone(),
+        mint_staging_jwt(&funded_solana_wallet_owner_subject_id)?,
+    ));
+
+    let result = debug_response!(
+        client.wallets().solana().sign_and_send_transaction_with_options(
+            &funded_solana_wallet_id,
+            "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+            &transaction,
+            &ctx,
+            None,
+            &options,
+        )
+    )
+    .await?;
+
+    println!("Solana sponsored transaction sent: {result:?}");
+
+    match result.into_inner() {
+        WalletRpcResponse::SolanaSignAndSendTransactionRpcResponse(_) => {}
+        _ => panic!("Expected SolanaSignAndSendTransactionRpcResponse"),
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[traced_test]
 async fn test_ethereum_wallet_import() -> Result<()> {
     let client = get_test_client()?;
 


### PR DESCRIPTION
## Summary
- Adds `send_transaction_with_options()` to `EthereumService` and `sign_and_send_transaction_with_options()` to `SolanaService` (Rust doesn't allow method overloads and doesn't have default params so had to create a new function with new params set)
- Uses `#[non_exhaustive]` options structs (`SendTransactionOptions`, `SignAndSendTransactionOptions`) with builder pattern for forward compatibility
- Existing `send_transaction()` and `sign_and_send_transaction()` methods are unchanged (no breaking change)
- Callers can now enable gas sponsorship: `SendTransactionOptions::new().with_sponsor(true)`