### PR TITLE
fix: update wallet domain for regenerated types

### DIFF
--- a/examples/create_wallet.rs
+++ b/examples/create_wallet.rs
@@ -43,9 +43,11 @@ async fn main() -> Result<()> {
             &CreateWalletBody {
                 chain_type: WalletChainType::Solana,
                 additional_signers: None,
+                display_name: None,
+                external_id: None,
                 owner: None,
                 owner_id: None,
-                policy_ids: vec![],
+                policy_ids: None,
             },
         )
         .await?;

--- a/examples/create_wallet_ethereum.rs
+++ b/examples/create_wallet_ethereum.rs
@@ -37,9 +37,11 @@ async fn main() -> Result<()> {
             &CreateWalletBody {
                 chain_type: WalletChainType::Ethereum,
                 additional_signers: None,
+                display_name: None,
+                external_id: None,
                 owner: None,
                 owner_id: None,
-                policy_ids: vec![],
+                policy_ids: None,
             },
         )
         .await?;

--- a/examples/get_wallets.rs
+++ b/examples/get_wallets.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
         public_key
     );
 
-    let wallets = client.wallets().list(None, None, Some(5.0), None).await?;
+    let wallets = client.wallets().list(None, None, None, None, Some(5.0), None).await?;
 
     tracing::info!("got wallets: {:?}", wallets);
 

--- a/examples/jwt_authentication.rs
+++ b/examples/jwt_authentication.rs
@@ -18,7 +18,12 @@
 //! ```
 
 use anyhow::Result;
-use privy_rs::{PrivyClient, generated::types::AuthenticateBody};
+use privy_rs::{
+    PrivyClient,
+    generated::types::{
+        WalletAuthenticateRequestBody, WalletAuthenticateRequestBodyEncryptionType,
+    },
+};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -38,10 +43,10 @@ async fn main() -> Result<()> {
 
     let jwt_auth = client
         .wallets()
-        .authenticate_with_jwt(&AuthenticateBody {
+        .authenticate_with_jwt(&WalletAuthenticateRequestBody {
             user_jwt,
-            encryption_type: None,
-            recipient_public_key: None,
+            encryption_type: WalletAuthenticateRequestBodyEncryptionType::Hpke,
+            recipient_public_key: String::new(),
         })
         .await?;
 

--- a/examples/update_wallet.rs
+++ b/examples/update_wallet.rs
@@ -21,7 +21,7 @@ use anyhow::Result;
 use privy_rs::{
     AuthorizationContext, IntoKey, JwtUser, PrivateKey, PrivyApiError, PrivyClient,
     PrivySignedApiError,
-    generated::types::{OwnerInput, UpdateWalletBody},
+    generated::types::{OwnerInput, OwnerInputPublicKey, P256PublicKey, WalletUpdateRequestBody},
 };
 use tracing_subscriber::EnvFilter;
 
@@ -62,8 +62,10 @@ async fn main() -> Result<()> {
         .update(
             &wallet_id,
             &ctx,
-            &UpdateWalletBody {
-                owner: Some(OwnerInput::PublicKey(public_key.to_string())),
+            &WalletUpdateRequestBody {
+                owner: Some(OwnerInput::Variant1(OwnerInputPublicKey {
+                    public_key: P256PublicKey(public_key.to_string()),
+                })),
                 ..Default::default()
             },
         )

--- a/examples/wallet_balance.rs
+++ b/examples/wallet_balance.rs
@@ -20,8 +20,8 @@ use anyhow::Result;
 use privy_rs::{
     PrivyClient,
     generated::types::{
-        GetWalletBalanceAsset, GetWalletBalanceAssetString, GetWalletBalanceChain,
-        GetWalletBalanceChainString, GetWalletBalanceIncludeCurrency,
+        GetWalletBalanceAsset, GetWalletBalanceChain, GetWalletBalanceChainString,
+        GetWalletBalanceIncludeCurrency, WalletSolanaAsset,
     },
 };
 use tracing_subscriber::EnvFilter;
@@ -50,9 +50,10 @@ async fn main() -> Result<()> {
         .balance()
         .get(
             &wallet_id,
-            &GetWalletBalanceAsset::String(GetWalletBalanceAssetString::Sol),
-            &GetWalletBalanceChain::String(GetWalletBalanceChainString::Solana),
+            Some(&GetWalletBalanceAsset::WalletSolanaAsset(WalletSolanaAsset::Sol)),
+            Some(&GetWalletBalanceChain::String(GetWalletBalanceChainString::Solana)),
             Some(GetWalletBalanceIncludeCurrency::Usd),
+            None,
         )
         .await?;
 

--- a/examples/wallet_raw_sign.rs
+++ b/examples/wallet_raw_sign.rs
@@ -19,7 +19,7 @@
 use anyhow::Result;
 use privy_rs::{
     AuthorizationContext, JwtUser, PrivateKey, PrivyApiError, PrivyClient, PrivySignedApiError,
-    generated::types::{RawSign, RawSignParams},
+    generated::types::{RawSignHashParams, RawSignInput, RawSignInputParams},
 };
 use tracing_subscriber::EnvFilter;
 
@@ -55,10 +55,10 @@ async fn main() -> Result<()> {
             &wallet_id,
             &ctx,
             None, // No idempotency key
-            &RawSign {
-                params: RawSignParams::Hash {
-                    hash: "0xdeadbeef".to_string(),
-                },
+            &RawSignInput {
+                params: RawSignInputParams::HashParams(RawSignHashParams {
+                    hash: "0xdeadbeef".parse().unwrap(),
+                }),
             },
         )
         .await

--- a/examples/wallet_rpc.rs
+++ b/examples/wallet_rpc.rs
@@ -22,7 +22,8 @@ use privy_rs::{
     AuthorizationContext, JwtUser, PrivateKey, PrivyApiError, PrivyClient, PrivySignedApiError,
     generated::types::{
         SolanaSignMessageRpcInput, SolanaSignMessageRpcInputMethod,
-        SolanaSignMessageRpcInputParams, SolanaSignMessageRpcInputParamsEncoding, WalletRpcBody,
+        SolanaSignMessageRpcInputParams, SolanaSignMessageRpcInputParamsEncoding,
+        WalletRpcRequestBody,
     },
 };
 use tracing_subscriber::EnvFilter;
@@ -59,14 +60,15 @@ async fn main() -> Result<()> {
             &wallet_id,
             &ctx,
             None, // No idempotency key
-            &WalletRpcBody::SolanaSignMessageRpcInput(SolanaSignMessageRpcInput {
+            &WalletRpcRequestBody::SolanaSignMessageRpcInput(SolanaSignMessageRpcInput {
                 address: Some("7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV".to_string()),
                 chain_type: None,
                 method: SolanaSignMessageRpcInputMethod::SignMessage,
                 params: SolanaSignMessageRpcInputParams {
                     encoding: SolanaSignMessageRpcInputParamsEncoding::Base64,
-                    message: STANDARD.encode("hello world"),
+                    message: STANDARD.encode("hello world").parse().unwrap(),
                 },
+                wallet_id: None,
             }),
         )
         .await

--- a/examples/wallet_transactions.rs
+++ b/examples/wallet_transactions.rs
@@ -20,7 +20,7 @@ use anyhow::Result;
 use privy_rs::{
     PrivyClient,
     generated::types::{
-        WalletTransactionsAsset, WalletTransactionsAssetString, WalletTransactionsChain,
+        WalletEthereumAsset, WalletTransactionsAsset, WalletTransactionsChain,
     },
 };
 use tracing_subscriber::EnvFilter;
@@ -43,16 +43,17 @@ async fn main() -> Result<()> {
         wallet_id
     );
 
-    // Get SOL transactions on Solana mainnet
+    // Get ETH transactions on Base
     let transactions = client
         .wallets()
         .transactions()
         .get(
             &wallet_id,
-            &WalletTransactionsAsset::String(WalletTransactionsAssetString::Sol),
+            Some(&WalletTransactionsAsset::WalletEthereumAsset(WalletEthereumAsset::Eth)),
             WalletTransactionsChain::Base,
             None,       // No cursor for first page
-            Some(10.0), // Limit to 10 transactions,
+            Some(10.0), // Limit to 10 transactions
+            None,
             None,
         )
         .await?;

--- a/src/ethereum.rs
+++ b/src/ethereum.rs
@@ -11,16 +11,16 @@ use crate::{
         types::{
             EthereumPersonalSignRpcInput, EthereumPersonalSignRpcInputMethod,
             EthereumPersonalSignRpcInputParams, EthereumPersonalSignRpcInputParamsEncoding,
-            EthereumSecp256k1SignRpcInput, EthereumSecp256k1SignRpcInputMethod,
-            EthereumSecp256k1SignRpcInputParams, EthereumSendTransactionRpcInput,
-            EthereumSendTransactionRpcInputMethod, EthereumSendTransactionRpcInputParams,
-            EthereumSendTransactionRpcInputParamsTransaction,
-            EthereumSign7702AuthorizationRpcInput, EthereumSign7702AuthorizationRpcInputMethod,
+            EthereumPersonalSignRpcInputParamsMessage, EthereumSecp256k1SignRpcInput,
+            EthereumSecp256k1SignRpcInputMethod, EthereumSecp256k1SignRpcInputParams,
+            EthereumSendTransactionRpcInput, EthereumSendTransactionRpcInputMethod,
+            EthereumSendTransactionRpcInputParams, EthereumSign7702AuthorizationRpcInput,
+            EthereumSign7702AuthorizationRpcInputMethod,
             EthereumSign7702AuthorizationRpcInputParams, EthereumSignTransactionRpcInput,
             EthereumSignTransactionRpcInputMethod, EthereumSignTransactionRpcInputParams,
-            EthereumSignTransactionRpcInputParamsTransaction, EthereumSignTypedDataRpcInput,
-            EthereumSignTypedDataRpcInputMethod, EthereumSignTypedDataRpcInputParams,
-            EthereumSignTypedDataRpcInputParamsTypedData, WalletRpcBody, WalletRpcResponse,
+            EthereumSignTypedDataRpcInput, EthereumSignTypedDataRpcInputMethod,
+            EthereumSignTypedDataRpcInputParams, EthereumTypedDataInput, Hex,
+            UnsignedEthereumTransaction, WalletRpcRequestBody, WalletRpcResponse,
         },
     },
 };
@@ -162,14 +162,16 @@ impl EthereumService {
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
-        let rpc_body = WalletRpcBody::EthereumPersonalSignRpcInput(EthereumPersonalSignRpcInput {
+        let rpc_body = WalletRpcRequestBody::EthereumPersonalSignRpcInput(EthereumPersonalSignRpcInput {
             address: None,
             chain_type: None,
             method: EthereumPersonalSignRpcInputMethod::PersonalSign,
             params: EthereumPersonalSignRpcInputParams {
                 encoding: EthereumPersonalSignRpcInputParamsEncoding::Utf8,
-                message: message.to_string(),
+                message: message.parse::<EthereumPersonalSignRpcInputParamsMessage>()
+                    .map_err(|e| Error::InvalidRequest(e.to_string()))?,
             },
+            wallet_id: None,
         });
 
         self.wallets_client
@@ -223,14 +225,16 @@ impl EthereumService {
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
         let hex_message = format!("0x{}", hex::encode(message));
 
-        let rpc_body = WalletRpcBody::EthereumPersonalSignRpcInput(EthereumPersonalSignRpcInput {
+        let rpc_body = WalletRpcRequestBody::EthereumPersonalSignRpcInput(EthereumPersonalSignRpcInput {
             address: None,
             chain_type: None,
             method: EthereumPersonalSignRpcInputMethod::PersonalSign,
             params: EthereumPersonalSignRpcInputParams {
                 encoding: EthereumPersonalSignRpcInputParamsEncoding::Hex,
-                message: hex_message,
+                message: hex_message.parse::<EthereumPersonalSignRpcInputParamsMessage>()
+                    .map_err(|e| Error::InvalidRequest(e.to_string()))?,
             },
+            wallet_id: None,
         });
 
         self.wallets_client
@@ -290,13 +294,15 @@ impl EthereumService {
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
         let rpc_body =
-            WalletRpcBody::EthereumSecp256k1SignRpcInput(EthereumSecp256k1SignRpcInput {
+            WalletRpcRequestBody::EthereumSecp256k1SignRpcInput(EthereumSecp256k1SignRpcInput {
                 address: None,
                 chain_type: None,
                 method: EthereumSecp256k1SignRpcInputMethod::Secp256k1Sign,
                 params: EthereumSecp256k1SignRpcInputParams {
-                    hash: hash.to_string(),
+                    hash: hash.parse::<Hex>()
+                        .map_err(|e| Error::InvalidRequest(e.to_string()))?,
                 },
+                wallet_id: None,
             });
 
         self.wallets_client
@@ -334,8 +340,9 @@ impl EthereumService {
     /// let auth_ctx = AuthorizationContext::new();
     ///
     /// let params = EthereumSign7702AuthorizationRpcInputParams {
-    ///     chain_id: EthereumSign7702AuthorizationRpcInputParamsChainId::Integer(1),
-    ///     contract: "0x1234567890abcdef1234567890abcdef12345678".to_string(),
+    ///     chain_id: Quantity::Integer(1),
+    ///     contract: "0x1234567890abcdef1234567890abcdef12345678".into(),
+    ///     executor: None,
     ///     nonce: None,
     /// };
     ///
@@ -354,12 +361,13 @@ impl EthereumService {
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
-        let rpc_body = WalletRpcBody::EthereumSign7702AuthorizationRpcInput(
+        let rpc_body = WalletRpcRequestBody::EthereumSign7702AuthorizationRpcInput(
             EthereumSign7702AuthorizationRpcInput {
                 address: None,
                 chain_type: None,
                 method: EthereumSign7702AuthorizationRpcInputMethod::EthSign7702Authorization,
                 params,
+                wallet_id: None,
             },
         );
 
@@ -398,11 +406,11 @@ impl EthereumService {
     /// let auth_ctx = AuthorizationContext::new();
     ///
     /// // Create EIP-712 typed data structure
-    /// let typed_data = EthereumSignTypedDataRpcInputParamsTypedData {
-    ///     domain: Default::default(),
-    ///     message: Default::default(),
+    /// let typed_data = EthereumTypedDataInput {
+    ///     domain: TypedDataDomainInputParams(serde_json::Map::new()),
+    ///     message: serde_json::Map::new(),
     ///     primary_type: "Mail".to_string(),
-    ///     types: Default::default(),
+    ///     types: TypedDataTypesInputParams(std::collections::HashMap::new()),
     /// };
     ///
     /// let signature = ethereum_service
@@ -422,16 +430,17 @@ impl EthereumService {
     pub async fn sign_typed_data(
         &self,
         wallet_id: &str,
-        typed_data: EthereumSignTypedDataRpcInputParamsTypedData,
+        typed_data: EthereumTypedDataInput,
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
         let rpc_body =
-            WalletRpcBody::EthereumSignTypedDataRpcInput(EthereumSignTypedDataRpcInput {
+            WalletRpcRequestBody::EthereumSignTypedDataRpcInput(EthereumSignTypedDataRpcInput {
                 address: None,
                 chain_type: None,
                 method: EthereumSignTypedDataRpcInputMethod::EthSignTypedDataV4,
                 params: EthereumSignTypedDataRpcInputParams { typed_data },
+                wallet_id: None,
             });
 
         self.wallets_client
@@ -467,7 +476,7 @@ impl EthereumService {
     /// let ethereum_service = client.wallets().ethereum();
     /// let auth_ctx = AuthorizationContext::new();
     ///
-    /// let transaction = EthereumSignTransactionRpcInputParamsTransaction {
+    /// let transaction = UnsignedStandardEthereumTransaction {
     ///     to: Some("0x742d35Cc6635C0532925a3b8c17d6d1E9C2F7ca".to_string()),
     ///     value: None,
     ///     gas_limit: None,
@@ -479,10 +488,11 @@ impl EthereumService {
     ///     max_fee_per_gas: None,
     ///     max_priority_fee_per_gas: None,
     ///     type_: None,
+    ///     authorization_list: vec![],
     /// };
     ///
     /// let signed_tx = ethereum_service
-    ///     .sign_transaction("clz2rqy4500061234abcd1234", transaction, &auth_ctx, None)
+    ///     .sign_transaction("clz2rqy4500061234abcd1234", transaction.into(), &auth_ctx, None)
     ///     .await?;
     ///
     /// println!("Transaction signed successfully");
@@ -492,16 +502,17 @@ impl EthereumService {
     pub async fn sign_transaction(
         &self,
         wallet_id: &str,
-        transaction: EthereumSignTransactionRpcInputParamsTransaction,
+        transaction: UnsignedEthereumTransaction,
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
         let rpc_body =
-            WalletRpcBody::EthereumSignTransactionRpcInput(EthereumSignTransactionRpcInput {
+            WalletRpcRequestBody::EthereumSignTransactionRpcInput(EthereumSignTransactionRpcInput {
                 address: None,
                 chain_type: None,
                 method: EthereumSignTransactionRpcInputMethod::EthSignTransaction,
                 params: EthereumSignTransactionRpcInputParams { transaction },
+                wallet_id: None,
             });
 
         self.wallets_client
@@ -538,25 +549,26 @@ impl EthereumService {
     /// let ethereum_service = client.wallets().ethereum();
     /// let auth_ctx = AuthorizationContext::new();
     ///
-    /// let transaction = EthereumSendTransactionRpcInputParamsTransaction {
+    /// let transaction = UnsignedStandardEthereumTransaction {
     ///     to: Some("0x742d35Cc6635C0532925a3b8c17d6d1E9C2F7ca".to_string()),
     ///     value: None,
     ///     gas_limit: None,
     ///     max_fee_per_gas: None,
     ///     max_priority_fee_per_gas: None,
-    ///     data: Some("0x".to_string()),
+    ///     data: None,
     ///     chain_id: None,
     ///     from: None,
     ///     gas_price: None,
     ///     nonce: None,
     ///     type_: None,
+    ///     authorization_list: vec![],
     /// };
     ///
     /// let result = ethereum_service
     ///     .send_transaction(
     ///         "clz2rqy4500061234abcd1234",
     ///         "eip155:1",
-    ///         transaction,
+    ///         transaction.into(),
     ///         &auth_ctx,
     ///         None,
     ///     )
@@ -577,7 +589,7 @@ impl EthereumService {
         &self,
         wallet_id: &str,
         caip2: &str,
-        transaction: EthereumSendTransactionRpcInputParamsTransaction,
+        transaction: UnsignedEthereumTransaction,
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
@@ -609,12 +621,13 @@ impl EthereumService {
     /// let ethereum_service = client.wallets().ethereum();
     /// let auth_ctx = AuthorizationContext::new();
     ///
-    /// let transaction = EthereumSendTransactionRpcInputParamsTransaction {
+    /// let transaction: UnsignedEthereumTransaction = UnsignedStandardEthereumTransaction {
     ///     to: Some("0x742d35Cc6635C0532925a3b8c17d6d1E9C2F7ca".to_string()),
     ///     value: None, gas_limit: None, max_fee_per_gas: None,
     ///     max_priority_fee_per_gas: None, data: None, chain_id: None,
     ///     from: None, gas_price: None, nonce: None, type_: None,
-    /// };
+    ///     authorization_list: vec![],
+    /// }.into();
     ///
     /// let options = SendTransactionOptions::new().with_sponsor(true);
     ///
@@ -635,21 +648,24 @@ impl EthereumService {
         &self,
         wallet_id: &str,
         caip2: &str,
-        transaction: EthereumSendTransactionRpcInputParamsTransaction,
+        transaction: UnsignedEthereumTransaction,
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
         options: &SendTransactionOptions,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
         let rpc_body =
-            WalletRpcBody::EthereumSendTransactionRpcInput(EthereumSendTransactionRpcInput {
+            WalletRpcRequestBody::EthereumSendTransactionRpcInput(EthereumSendTransactionRpcInput {
                 address: None,
                 caip2: caip2
                     .parse()
                     .map_err(|_| Error::InvalidRequest("Invalid CAIP-2 format".to_string()))?,
                 chain_type: None,
+                experimental_data_suffix: None,
                 method: EthereumSendTransactionRpcInputMethod::EthSendTransaction,
                 params: EthereumSendTransactionRpcInputParams { transaction },
+                reference_id: None,
                 sponsor: options.sponsor,
+                wallet_id: None,
             });
 
         self.wallets_client

--- a/src/import.rs
+++ b/src/import.rs
@@ -9,9 +9,9 @@ use crate::{
     generated::{
         Error, ResponseValue,
         types::{
-            PrivateKeySubmitInput, Wallet, WalletImportInitializationRequest,
-            WalletImportInitializationResponse, WalletImportSubmissionRequest,
-            WalletImportSubmissionRequestOwner, WalletImportSubmissionRequestWallet,
+            AdditionalSignerInput, OwnerInput, PolicyInput, PrivateKeySubmitInput, Wallet,
+            WalletImportInitBody, WalletImportInitializationResponse,
+            WalletImportSubmissionRequest, WalletImportSubmissionRequestWallet,
             WalletImportSupportedChains,
         },
     },
@@ -28,13 +28,13 @@ pub struct WalletImport {
 impl WalletImport {
     pub(crate) async fn new(
         client: WalletsClient,
-        request: WalletImportInitializationRequest,
+        request: WalletImportInitBody,
     ) -> Result<Self, PrivyApiError> {
         let (address, chain_type) = match &request {
-            WalletImportInitializationRequest::PrivateKeyInitInput(input) => {
+            WalletImportInitBody::PrivateKeyInitInput(input) => {
                 (input.address.to_owned(), input.chain_type)
             }
-            WalletImportInitializationRequest::HdInitInput(input) => {
+            WalletImportInitBody::HdInitInput(input) => {
                 (input.address.to_owned(), input.chain_type)
             }
         };
@@ -94,11 +94,9 @@ impl WalletImport {
     pub(crate) async fn submit(
         self,
         private_key_hex: &str,
-        owner: Option<WalletImportSubmissionRequestOwner>,
+        owner: Option<OwnerInput>,
         policy_ids: Vec<String>,
-        additional_signers: Vec<
-            crate::generated::types::WalletImportSubmissionRequestAdditionalSignersItem,
-        >,
+        additional_signers: Option<AdditionalSignerInput>,
     ) -> Result<ResponseValue<Wallet>, PrivyApiError> {
         // Encrypt the private key using HPKE
         let (ciphertext, encapsulated_key) = self
@@ -113,6 +111,7 @@ impl WalletImport {
             encapsulated_key,
             encryption_type: self.initialization_response.encryption_type,
             entropy_type: crate::generated::types::PrivateKeySubmitInputEntropyType::PrivateKey,
+            hpke_config: None,
         };
 
         // Create the submission request
@@ -120,8 +119,10 @@ impl WalletImport {
             wallet: WalletImportSubmissionRequestWallet::PrivateKeySubmitInput(wallet_input),
             owner,
             owner_id: None,
-            policy_ids,
+            policy_ids: Some(PolicyInput(policy_ids)),
             additional_signers,
+            display_name: None,
+            external_id: None,
         };
 
         // Submit the import request

--- a/src/jwt_exchange.rs
+++ b/src/jwt_exchange.rs
@@ -6,7 +6,12 @@ use std::{
 
 use p256::{NistP256, elliptic_curve::SecretKey};
 
-use crate::{JwtUser, KeyError, PrivyHpke, generated::types::AuthenticateBody};
+use crate::{
+    JwtUser, KeyError, PrivyHpke,
+    generated::types::{
+        WalletAuthenticateRequestBody, WalletAuthenticateRequestBodyEncryptionType,
+    },
+};
 
 const EXPIRY_BUFFER: Duration = Duration::from_secs(60);
 
@@ -68,10 +73,10 @@ impl JwtExchange {
         );
 
         // Build the authentication request with encryption parameters
-        let body = AuthenticateBody {
+        let body = WalletAuthenticateRequestBody {
             user_jwt: jwt.clone(),
-            encryption_type: Some(crate::generated::types::AuthenticateBodyEncryptionType::Hpke),
-            recipient_public_key: Some(public_key_b64),
+            encryption_type: WalletAuthenticateRequestBodyEncryptionType::Hpke,
+            recipient_public_key: public_key_b64,
         };
 
         // Send the authentication request
@@ -85,7 +90,7 @@ impl JwtExchange {
 
         // Process the response based on encryption type
         let (key, expiry) = match auth {
-            crate::generated::types::AuthenticateResponse::WithEncryption {
+            crate::generated::types::WalletAuthenticateWithJwtResponse::WithEncryption {
                 encrypted_authorization_key,
                 expires_at,
                 ..
@@ -100,7 +105,9 @@ impl JwtExchange {
                 let expiry = SystemTime::UNIX_EPOCH + Duration::from_secs_f64(expires_at);
                 (key, expiry)
             }
-            crate::generated::types::AuthenticateResponse::WithoutEncryption { .. } => {
+            crate::generated::types::WalletAuthenticateWithJwtResponse::WithoutEncryption {
+                ..
+            } => {
                 tracing::warn!("Received unencrypted authorization key (fallback mode)");
                 unimplemented!()
             }

--- a/src/solana.rs
+++ b/src/solana.rs
@@ -12,13 +12,16 @@ use crate::{
     generated::{
         Error, ResponseValue,
         types::{
-            SolanaSignAndSendTransactionRpcInput, SolanaSignAndSendTransactionRpcInputCaip2,
+            Caip2, SolanaSignAndSendTransactionRpcInput,
             SolanaSignAndSendTransactionRpcInputMethod, SolanaSignAndSendTransactionRpcInputParams,
-            SolanaSignAndSendTransactionRpcInputParamsEncoding, SolanaSignMessageRpcInput,
+            SolanaSignAndSendTransactionRpcInputParamsEncoding,
+            SolanaSignAndSendTransactionRpcInputParamsTransaction, SolanaSignMessageRpcInput,
             SolanaSignMessageRpcInputMethod, SolanaSignMessageRpcInputParams,
-            SolanaSignMessageRpcInputParamsEncoding, SolanaSignTransactionRpcInput,
-            SolanaSignTransactionRpcInputMethod, SolanaSignTransactionRpcInputParams,
-            SolanaSignTransactionRpcInputParamsEncoding, WalletRpcBody, WalletRpcResponse,
+            SolanaSignMessageRpcInputParamsEncoding, SolanaSignMessageRpcInputParamsMessage,
+            SolanaSignTransactionRpcInput, SolanaSignTransactionRpcInputMethod,
+            SolanaSignTransactionRpcInputParams, SolanaSignTransactionRpcInputParamsEncoding,
+            SolanaSignTransactionRpcInputParamsTransaction, WalletRpcRequestBody,
+            WalletRpcResponse,
         },
     },
 };
@@ -167,14 +170,16 @@ impl SolanaService {
         authorization_context: &AuthorizationContext,
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
-        let rpc_body = WalletRpcBody::SolanaSignMessageRpcInput(SolanaSignMessageRpcInput {
+        let rpc_body = WalletRpcRequestBody::SolanaSignMessageRpcInput(SolanaSignMessageRpcInput {
             address: None,
             chain_type: None,
             method: SolanaSignMessageRpcInputMethod::SignMessage,
             params: SolanaSignMessageRpcInputParams {
                 encoding: SolanaSignMessageRpcInputParamsEncoding::Base64,
-                message: message.to_string(),
+                message: message.parse::<SolanaSignMessageRpcInputParamsMessage>()
+                    .map_err(|e| Error::InvalidRequest(e.to_string()))?,
             },
+            wallet_id: None,
         });
 
         self.wallets_client
@@ -238,14 +243,16 @@ impl SolanaService {
         idempotency_key: Option<&str>,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
         let rpc_body =
-            WalletRpcBody::SolanaSignTransactionRpcInput(SolanaSignTransactionRpcInput {
+            WalletRpcRequestBody::SolanaSignTransactionRpcInput(SolanaSignTransactionRpcInput {
                 address: None,
                 chain_type: None,
                 method: SolanaSignTransactionRpcInputMethod::SignTransaction,
                 params: SolanaSignTransactionRpcInputParams {
                     encoding: SolanaSignTransactionRpcInputParamsEncoding::Base64,
-                    transaction: transaction.to_string(),
+                    transaction: transaction.parse::<SolanaSignTransactionRpcInputParamsTransaction>()
+                        .map_err(|e| Error::InvalidRequest(e.to_string()))?,
                 },
+                wallet_id: None,
             });
 
         self.wallets_client
@@ -372,20 +379,24 @@ impl SolanaService {
         idempotency_key: Option<&str>,
         options: &SignAndSendTransactionOptions,
     ) -> Result<ResponseValue<WalletRpcResponse>, PrivySignedApiError> {
-        let caip2_parsed = SolanaSignAndSendTransactionRpcInputCaip2::from_str(caip2)
+        let caip2_parsed = Caip2::from_str(caip2)
             .map_err(|_| Error::InvalidRequest("Invalid CAIP-2 format".to_string()))?;
 
-        let rpc_body = WalletRpcBody::SolanaSignAndSendTransactionRpcInput(
+        let rpc_body = WalletRpcRequestBody::SolanaSignAndSendTransactionRpcInput(
             SolanaSignAndSendTransactionRpcInput {
                 address: None,
                 caip2: caip2_parsed,
                 chain_type: None,
                 method: SolanaSignAndSendTransactionRpcInputMethod::SignAndSendTransaction,
+                optimistic_broadcast: None,
                 params: SolanaSignAndSendTransactionRpcInputParams {
                     encoding: SolanaSignAndSendTransactionRpcInputParamsEncoding::Base64,
-                    transaction: transaction.to_string(),
+                    transaction: transaction.parse::<SolanaSignAndSendTransactionRpcInputParamsTransaction>()
+                        .map_err(|e| Error::InvalidRequest(e.to_string()))?,
                 },
+                reference_id: None,
                 sponsor: options.sponsor,
+                wallet_id: None,
             },
         );
 

--- a/src/subclients/wallets.rs
+++ b/src/subclients/wallets.rs
@@ -4,9 +4,8 @@ use crate::{
     ethereum::EthereumService,
     generate_authorization_signatures,
     generated::types::{
-        HpkeEncryption, PrivateKeyInitInput, Wallet, WalletExportRequestBody,
-        WalletImportSubmissionRequestAdditionalSignersItem, WalletImportSubmissionRequestOwner,
-        WalletImportSupportedChains,
+        AdditionalSignerInput, HpkeEncryption, OwnerInput, PrivateKeyInitInput, Wallet,
+        WalletExportRequestBody, WalletImportSupportedChains,
     },
     import::WalletImport,
     solana::SolanaService,
@@ -26,7 +25,7 @@ impl WalletsClient {
         wallet_id: &'a str,
         ctx: &'a AuthorizationContext,
         privy_idempotency_key: Option<&'a str>,
-        body: &'a crate::generated::types::WalletRpcBody,
+        body: &'a crate::generated::types::WalletRpcRequestBody,
     ) -> Result<ResponseValue<crate::generated::types::WalletRpcResponse>, PrivySignedApiError>
     {
         let sig = generate_authorization_signatures(
@@ -40,7 +39,7 @@ impl WalletsClient {
         .await?;
 
         Ok(self
-            ._rpc(wallet_id, Some(&sig), privy_idempotency_key, body)
+            ._rpc(wallet_id, Some(&sig), privy_idempotency_key, None, body)
             .await?)
     }
 
@@ -56,7 +55,7 @@ impl WalletsClient {
         wallet_id: &'a str,
         ctx: &'a AuthorizationContext,
         privy_idempotency_key: Option<&'a str>,
-        body: &'a crate::generated::types::RawSign,
+        body: &'a crate::generated::types::RawSignInput,
     ) -> Result<ResponseValue<crate::generated::types::RawSignResponse>, PrivySignedApiError> {
         let sig = generate_authorization_signatures(
             ctx,
@@ -69,7 +68,7 @@ impl WalletsClient {
         .await?;
 
         Ok(self
-            ._raw_sign(wallet_id, Some(&sig), privy_idempotency_key, body)
+            ._raw_sign(wallet_id, Some(&sig), privy_idempotency_key, None, body)
             .await?)
     }
 
@@ -83,7 +82,7 @@ impl WalletsClient {
         &'a self,
         wallet_id: &'a str,
         ctx: &'a AuthorizationContext,
-        body: &'a crate::generated::types::UpdateWalletBody,
+        body: &'a crate::generated::types::WalletUpdateRequestBody,
     ) -> Result<ResponseValue<crate::generated::types::Wallet>, PrivySignedApiError> {
         let sig = generate_authorization_signatures(
             ctx,
@@ -95,7 +94,7 @@ impl WalletsClient {
         )
         .await?;
 
-        Ok(self._update(wallet_id, Some(&sig), body).await?)
+        Ok(self._update(wallet_id, Some(&sig), None, body).await?)
     }
 
     /// Export a wallet
@@ -115,6 +114,7 @@ impl WalletsClient {
         let privy_hpke = PrivyHpke::new();
         let body = WalletExportRequestBody {
             encryption_type: HpkeEncryption::Hpke,
+            export_seed_phrase: None,
             recipient_public_key: privy_hpke.public_key()?,
         };
 
@@ -128,7 +128,7 @@ impl WalletsClient {
         )
         .await?;
 
-        let resp = self._export(wallet_id, Some(&sig), &body).await?;
+        let resp = self._export(wallet_id, Some(&sig), None, &body).await?;
 
         tracing::debug!("Encapsulated key: {:?}", resp);
 
@@ -143,13 +143,13 @@ impl WalletsClient {
         address: String,
         private_key_hex: &str,
         chain_type: WalletImportSupportedChains,
-        owner: Option<WalletImportSubmissionRequestOwner>,
+        owner: Option<OwnerInput>,
         policy_ids: Vec<String>,
-        additional_signers: Vec<WalletImportSubmissionRequestAdditionalSignersItem>,
+        additional_signers: Option<AdditionalSignerInput>,
     ) -> Result<ResponseValue<Wallet>, PrivyApiError> {
         WalletImport::new(
             self.clone(),
-            crate::generated::types::WalletImportInitializationRequest::PrivateKeyInitInput(
+            crate::generated::types::WalletImportInitBody::PrivateKeyInitInput(
                 PrivateKeyInitInput {
                     address: address.clone(),
                     chain_type,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -211,7 +211,7 @@ mod tests {
     use super::*;
     use crate::{
         AuthorizationContext, IntoKey, PrivateKey,
-        generated::types::{OwnerInput, UpdateWalletBody},
+        generated::types::{OwnerInput, OwnerInputPublicKey, P256PublicKey, WalletUpdateRequestBody},
         get_auth_header,
     };
 
@@ -224,8 +224,10 @@ mod tests {
         let public_key = key.get_key().await.unwrap().public_key();
 
         // Create the request body that will be sent using the generated privy-api type
-        let update_wallet_body = UpdateWalletBody {
-            owner: Some(OwnerInput::PublicKey(public_key.to_string())),
+        let update_wallet_body = WalletUpdateRequestBody {
+            owner: Some(OwnerInput::Variant1(OwnerInputPublicKey {
+                public_key: P256PublicKey(public_key.to_string()),
+            })),
             ..Default::default()
         };
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -130,9 +130,13 @@ pub async fn get_test_wallet_by_type(
             &CreateWalletBody {
                 chain_type,
                 additional_signers: None,
-                owner: owner.map(|o| OwnerInput::UserId(o.to_string())),
+                owner: owner.map(|o| OwnerInput::Variant0(OwnerInputUser {
+                    user_id: o.to_string(),
+                })),
                 owner_id: None,
-                policy_ids: vec![],
+                policy_ids: None,
+                display_name: None,
+                external_id: None,
             },
         )
         .await?;
@@ -193,19 +197,19 @@ pub async fn ensure_test_user(client: &PrivyClient) -> Result<User> {
 
 pub async fn ensure_test_policy(
     client: &PrivyClient,
-    rules: Vec<PolicyRuleRequestBody>,
+    rules: Vec<CreatePolicyBodyRulesItem>,
 ) -> Result<Policy> {
     ensure_test_policy_with_user(client, rules, None).await
 }
 
 pub async fn ensure_test_policy_with_user(
     client: &PrivyClient,
-    rules: Vec<PolicyRuleRequestBody>,
+    rules: Vec<CreatePolicyBodyRulesItem>,
     user: Option<OwnerInput>,
 ) -> Result<Policy> {
     let unique_name = format!("test-policy-{}", chrono::Utc::now().timestamp());
     let policy_body = CreatePolicyBody {
-        chain_type: PolicyChainType::Solana,
+        chain_type: WalletChainType::Solana,
         name: CreatePolicyBodyName::try_from(unique_name).unwrap(),
         owner: user,
         owner_id: None,

--- a/tests/ethereum.rs
+++ b/tests/ethereum.rs
@@ -16,15 +16,16 @@ async fn test_ethereum_sign_message() -> Result<()> {
     let client = get_test_client()?;
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
 
-    let rpc_body: WalletRpcBody =
-        WalletRpcBody::EthereumPersonalSignRpcInput(EthereumPersonalSignRpcInput {
+    let rpc_body: WalletRpcRequestBody =
+        WalletRpcRequestBody::EthereumPersonalSignRpcInput(EthereumPersonalSignRpcInput {
             address: Some("0xdadB0d80178819F2319190D340ce9A924f783711".to_string()),
             chain_type: Some(EthereumPersonalSignRpcInputChainType::Ethereum),
             method: EthereumPersonalSignRpcInputMethod::PersonalSign,
             params: EthereumPersonalSignRpcInputParams {
                 encoding: EthereumPersonalSignRpcInputParamsEncoding::Utf8,
-                message: "Hello world".to_string(),
+                message: "Hello world".parse().unwrap(),
             },
+            wallet_id: None,
         });
 
     let result = debug_response!(client.wallets().rpc(
@@ -50,13 +51,14 @@ async fn test_ethereum_sign_typed_data() -> Result<()> {
     let client = get_test_client()?;
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
 
-    let rpc_body = WalletRpcBody::EthereumSignTypedDataRpcInput(EthereumSignTypedDataRpcInput {
+    let rpc_body = WalletRpcRequestBody::EthereumSignTypedDataRpcInput(EthereumSignTypedDataRpcInput {
         address: None,
         chain_type: None,
         method: EthereumSignTypedDataRpcInputMethod::EthSignTypedDataV4,
+        wallet_id: None,
         params: EthereumSignTypedDataRpcInputParams {
-            typed_data: EthereumSignTypedDataRpcInputParamsTypedData {
-                domain: serde_json::Map::from_iter([
+            typed_data: EthereumTypedDataInput {
+                domain: TypedDataDomainInputParams(serde_json::Map::from_iter([
                     ("name".to_string(), serde_json::json!("DApp Mail")),
                     ("version".to_string(), serde_json::json!("1")),
                     ("chainId".to_string(), serde_json::json!("0x3e8")),
@@ -64,7 +66,7 @@ async fn test_ethereum_sign_typed_data() -> Result<()> {
                         "verifyingContract".to_string(),
                         serde_json::json!("0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"),
                     ),
-                ]),
+                ])),
                 message: serde_json::Map::from_iter([
                     (
                         "from".to_string(),
@@ -83,23 +85,23 @@ async fn test_ethereum_sign_typed_data() -> Result<()> {
                     ("contents".to_string(), serde_json::json!("Hello, Bob!")),
                 ]),
                 primary_type: "Mail".to_string(),
-                types: [
+                types: TypedDataTypesInputParams(std::collections::HashMap::from([
                     (
                         "EIP712Domain".to_string(),
                         vec![
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "name".to_string(),
                                 type_: "string".to_string(),
                             },
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "version".to_string(),
                                 type_: "string".to_string(),
                             },
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "chainId".to_string(),
                                 type_: "uint256".to_string(),
                             },
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "verifyingContract".to_string(),
                                 type_: "address".to_string(),
                             },
@@ -108,11 +110,11 @@ async fn test_ethereum_sign_typed_data() -> Result<()> {
                     (
                         "Person".to_string(),
                         vec![
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "name".to_string(),
                                 type_: "string".to_string(),
                             },
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "wallet".to_string(),
                                 type_: "address".to_string(),
                             },
@@ -121,22 +123,21 @@ async fn test_ethereum_sign_typed_data() -> Result<()> {
                     (
                         "Mail".to_string(),
                         vec![
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "from".to_string(),
                                 type_: "Person".to_string(),
                             },
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "to".to_string(),
                                 type_: "Person".to_string(),
                             },
-                            EthereumSignTypedDataRpcInputParamsTypedDataTypesValueItem {
+                            TypedDataTypeFieldInput {
                                 name: "contents".to_string(),
                                 type_: "string".to_string(),
                             },
                         ],
                     ),
-                ]
-                .into(),
+                ])),
             },
         },
     });
@@ -164,13 +165,14 @@ async fn test_ethereum_sign_secp256k1() -> Result<()> {
     let client = get_test_client()?;
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
 
-    let rpc_body = WalletRpcBody::EthereumSecp256k1SignRpcInput(EthereumSecp256k1SignRpcInput {
+    let rpc_body = WalletRpcRequestBody::EthereumSecp256k1SignRpcInput(EthereumSecp256k1SignRpcInput {
         address: None,
         chain_type: None,
         method: privy_rs::generated::types::EthereumSecp256k1SignRpcInputMethod::Secp256k1Sign,
         params: privy_rs::generated::types::EthereumSecp256k1SignRpcInputParams {
-            hash: "0x12345678".to_string(),
+            hash: "0x12345678".parse().unwrap(),
         },
+        wallet_id: None,
     });
 
     let result = debug_response!(client.wallets().rpc(
@@ -196,16 +198,18 @@ async fn test_ethereum_sign_7702_authorization() -> Result<()> {
     let client = get_test_client()?;
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
 
-    let rpc_body = WalletRpcBody::EthereumSign7702AuthorizationRpcInput(
+    let rpc_body = WalletRpcRequestBody::EthereumSign7702AuthorizationRpcInput(
         EthereumSign7702AuthorizationRpcInput {
             address: None,
             chain_type: None,
             method: EthereumSign7702AuthorizationRpcInputMethod::EthSign7702Authorization,
             params: EthereumSign7702AuthorizationRpcInputParams {
-                chain_id: EthereumSign7702AuthorizationRpcInputParamsChainId::Integer(1),
+                chain_id: Quantity::Integer(1),
                 contract: "0x1234567890abcdef1234567890abcdef12345678".into(),
+                executor: None,
                 nonce: None,
             },
+            wallet_id: None,
         },
     );
 
@@ -233,16 +237,15 @@ async fn test_ethereum_sign_transaction() -> Result<()> {
     let client = get_test_client()?;
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
 
-    let rpc_body = WalletRpcBody::EthereumSignTransactionRpcInput(
+    let rpc_body = WalletRpcRequestBody::EthereumSignTransactionRpcInput(
         privy_rs::generated::types::EthereumSignTransactionRpcInput {
             address: Some("0xdadB0d80178819F2319190D340ce9A924f783711".to_string()),
             chain_type: Some(privy_rs::generated::types::EthereumSignTransactionRpcInputChainType::Ethereum),
             method: privy_rs::generated::types::EthereumSignTransactionRpcInputMethod::EthSignTransaction,
             params: privy_rs::generated::types::EthereumSignTransactionRpcInputParams {
-                transaction: privy_rs::generated::types::EthereumSignTransactionRpcInputParamsTransaction {
-                    chain_id: None, data: None, from: None, gas_limit: None, gas_price: None, max_fee_per_gas: None, max_priority_fee_per_gas: None, nonce: None, to: None, type_: None, value: None
-                }
+                transaction: UnsignedStandardEthereumTransaction::default().into(),
             },
+            wallet_id: None,
         },
     );
 
@@ -277,30 +280,32 @@ async fn test_ethereum_send_transaction() -> Result<()> {
     let funded_ethereum_wallet_owner_subject_id =
         std::env::var("FUNDED_WALLETS_OWNER_SUBJECT_ID").unwrap_or("java-sdk-sub-id".to_string());
 
-    let rpc_body = WalletRpcBody::EthereumSendTransactionRpcInput(
+    let rpc_body = WalletRpcRequestBody::EthereumSendTransactionRpcInput(
         privy_rs::generated::types::EthereumSendTransactionRpcInput {
             address: None,
             caip2: "eip155:11155111".parse().unwrap(),
             chain_type: Some(EthereumSendTransactionRpcInputChainType::Ethereum),
+            experimental_data_suffix: None,
             method: EthereumSendTransactionRpcInputMethod::EthSendTransaction,
             params: EthereumSendTransactionRpcInputParams {
-                transaction: EthereumSendTransactionRpcInputParamsTransaction {
+                transaction: UnsignedStandardEthereumTransaction {
                     to: Some("0xa8BABAc2A6d66Db720D8271e7a85fB0CB78A5377".to_string()),
-                    value: Some(
-                        EthereumSendTransactionRpcInputParamsTransactionValue::Integer(100),
-                    ),
+                    value: Some(Quantity::Integer(100)),
                     chain_id: None,
                     from: Some(funded_ethereum_wallet_address.clone()),
                     max_fee_per_gas: None,
                     max_priority_fee_per_gas: None,
                     nonce: None,
                     type_: None,
-                    data: Some("0x".to_string()),
+                    data: Some("0x".parse().unwrap()),
                     gas_limit: None,
                     gas_price: None,
-                },
+                    authorization_list: vec![],
+                }.into(),
             },
+            reference_id: None,
             sponsor: Some(false),
+            wallet_id: None,
         },
     );
 
@@ -342,18 +347,19 @@ async fn test_ethereum_send_transaction_with_options_sponsored() -> Result<()> {
     let recipient_address = std::env::var("ETHEREUM_RECIPIENT_ADDRESS")
         .expect("ETHEREUM_RECIPIENT_ADDRESS must be set");
 
-    let transaction = EthereumSendTransactionRpcInputParamsTransaction {
+    let transaction = UnsignedStandardEthereumTransaction {
         to: Some(recipient_address),
-        value: Some(EthereumSendTransactionRpcInputParamsTransactionValue::Integer(100)),
+        value: Some(Quantity::Integer(100)),
         chain_id: None,
         from: Some(funded_ethereum_wallet_address.clone()),
         max_fee_per_gas: None,
         max_priority_fee_per_gas: None,
         nonce: None,
         type_: None,
-        data: Some("0x".to_string()),
+        data: Some("0x".parse().unwrap()),
         gas_limit: None,
         gas_price: None,
+        authorization_list: vec![],
     };
 
     let options = privy_rs::SendTransactionOptions::new().with_sponsor(true);
@@ -366,7 +372,7 @@ async fn test_ethereum_send_transaction_with_options_sponsored() -> Result<()> {
     let result = debug_response!(client.wallets().ethereum().send_transaction_with_options(
         &funded_ethereum_wallet_id,
         "eip155:11155111",
-        transaction,
+        transaction.into(),
         &ctx,
         None,
         &options,
@@ -416,7 +422,7 @@ async fn test_ethereum_wallet_import() -> Result<()> {
             WalletImportSupportedChains::Ethereum,
             None,
             vec![],
-            vec![],
+            None,
         )
         .await?
         .into_inner();

--- a/tests/solana.rs
+++ b/tests/solana.rs
@@ -18,14 +18,15 @@ async fn test_solana_sign_message() -> Result<()> {
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Solana, None).await?;
 
     let message = "Hello, Solana!";
-    let rpc_body = WalletRpcBody::SolanaSignMessageRpcInput(SolanaSignMessageRpcInput {
+    let rpc_body = WalletRpcRequestBody::SolanaSignMessageRpcInput(SolanaSignMessageRpcInput {
         address: None,
         chain_type: None,
         method: SolanaSignMessageRpcInputMethod::SignMessage,
         params: SolanaSignMessageRpcInputParams {
             encoding: SolanaSignMessageRpcInputParamsEncoding::Base64,
-            message: STANDARD.encode(message),
+            message: STANDARD.encode(message).parse().unwrap(),
         },
+        wallet_id: None,
     });
 
     let result = debug_response!(client.wallets().rpc(
@@ -54,14 +55,15 @@ async fn test_solana_sign_transaction() -> Result<()> {
 
     let transaction = "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDArczbMia1tLmq7zz4DinMNN0pJ1JtLdqIJPUw3YrGCzYAMHBsgN27lcgB6H2WQvFgyZuJYHa46puOQo9yQ8CVQbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCp20C7Wj2aiuk5TReAXo+VTVg8QTHjs0UjNMMKCvpzZ+ABAgEBARU=";
 
-    let rpc_body = WalletRpcBody::SolanaSignTransactionRpcInput(SolanaSignTransactionRpcInput {
+    let rpc_body = WalletRpcRequestBody::SolanaSignTransactionRpcInput(SolanaSignTransactionRpcInput {
         address: None,
         chain_type: None,
         method: SolanaSignTransactionRpcInputMethod::SignTransaction,
         params: SolanaSignTransactionRpcInputParams {
             encoding: SolanaSignTransactionRpcInputParamsEncoding::Base64,
-            transaction: transaction.to_string(),
+            transaction: transaction.parse().unwrap(),
         },
+        wallet_id: None,
     });
 
     let result = debug_response!(client.wallets().rpc(
@@ -113,19 +115,19 @@ async fn test_solana_sign_and_send_transaction() -> Result<()> {
     let transaction = STANDARD.encode(bincode::serialize(&transaction).unwrap());
 
     let rpc_body =
-        WalletRpcBody::SolanaSignAndSendTransactionRpcInput(SolanaSignAndSendTransactionRpcInput {
+        WalletRpcRequestBody::SolanaSignAndSendTransactionRpcInput(SolanaSignAndSendTransactionRpcInput {
             address: None,
-            caip2: SolanaSignAndSendTransactionRpcInputCaip2::from_str(
-                "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
-            )
-            .unwrap(),
+            caip2: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1".parse().unwrap(),
             chain_type: None,
             method: SolanaSignAndSendTransactionRpcInputMethod::SignAndSendTransaction,
             params: SolanaSignAndSendTransactionRpcInputParams {
                 encoding: SolanaSignAndSendTransactionRpcInputParamsEncoding::Base64,
-                transaction,
+                transaction: transaction.parse().unwrap(),
             },
             sponsor: Some(false),
+            wallet_id: None,
+            optimistic_broadcast: None,
+            reference_id: None,
         });
 
     let ctx = AuthorizationContext::new().push(JwtUser(

--- a/tests/wallets.rs
+++ b/tests/wallets.rs
@@ -13,7 +13,7 @@ mod common;
 #[tokio::test]
 async fn test_wallets_list() -> Result<()> {
     let client = get_test_client()?;
-    let wallets = client.wallets().list(None, None, Some(10.0), None).await?;
+    let wallets = client.wallets().list(None, None, None, None, Some(10.0), None).await?;
 
     println!("Retrieved {} wallets", wallets.data.len());
 
@@ -29,7 +29,9 @@ async fn test_wallets_create() -> Result<()> {
         additional_signers: None,
         owner: None,
         owner_id: None,
-        policy_ids: vec![],
+        policy_ids: None,
+        display_name: None,
+        external_id: None,
     };
 
     let wallet = client.wallets().create(None, &create_body).await?;
@@ -79,16 +81,16 @@ async fn test_wallets_authenticate_with_jwt() -> Result<()> {
     tracing::info!("JWT token: {:?}", jwt_token);
 
     let privy_hpke = PrivyHpke::new();
-    let auth_body = AuthenticateBody {
-        encryption_type: Some(AuthenticateBodyEncryptionType::Hpke),
+    let auth_body = WalletAuthenticateRequestBody {
+        encryption_type: WalletAuthenticateRequestBodyEncryptionType::Hpke,
         user_jwt: jwt_token,
-        recipient_public_key: Some(privy_hpke.public_key().unwrap()),
+        recipient_public_key: privy_hpke.public_key().unwrap(),
     };
 
     let result = debug_response!(client.wallets().authenticate_with_jwt(&auth_body)).await?;
 
     match result.into_inner() {
-        AuthenticateResponse::WithEncryption { .. } => {
+        WalletAuthenticateWithJwtResponse::WithEncryption { .. } => {
             println!("JWT authentication successful for user: {}", user.id);
         }
         _ => panic!("Unexpected response type"),
@@ -102,10 +104,10 @@ async fn test_wallets_raw_sign_with_auth_context() -> Result<()> {
     let client = get_test_client()?;
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Tron, None).await?;
 
-    let raw_sign_body = privy_rs::generated::types::RawSign {
-        params: RawSignParams::Hash {
-            hash: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string(),
-        },
+    let raw_sign_body = privy_rs::generated::types::RawSignInput {
+        params: RawSignInputParams::HashParams(RawSignHashParams {
+            hash: "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".parse().unwrap(),
+        }),
     };
 
     let ctx = AuthorizationContext::new();
@@ -136,8 +138,10 @@ async fn test_wallets_update_with_auth_context() -> Result<()> {
     let private_key = PrivateKey::new(private_key.to_string());
     let public_key = private_key.get_key().await?.public_key();
 
-    let update_body = UpdateWalletBody {
-        owner: Some(OwnerInput::PublicKey(public_key.to_string())),
+    let update_body = WalletUpdateRequestBody {
+        owner: Some(OwnerInput::Variant1(OwnerInputPublicKey {
+            public_key: P256PublicKey(public_key.to_string()),
+        })),
         ..Default::default()
     };
 
@@ -149,8 +153,10 @@ async fn test_wallets_update_with_auth_context() -> Result<()> {
     let mut rng = rand::thread_rng();
     let other = SecretKey::<p256::NistP256>::random(&mut rng);
 
-    let update_body = UpdateWalletBody {
-        owner: Some(OwnerInput::PublicKey(other.public_key().to_string())),
+    let update_body = WalletUpdateRequestBody {
+        owner: Some(OwnerInput::Variant1(OwnerInputPublicKey {
+            public_key: P256PublicKey(other.public_key().to_string()),
+        })),
         ..Default::default()
     };
 
@@ -207,15 +213,16 @@ async fn test_wallets_transactions_get() -> Result<()> {
     let client = get_test_client()?;
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Ethereum, None).await?;
 
-    let asset = WalletTransactionsAsset::String(WalletTransactionsAssetString::Eth);
+    let asset = WalletTransactionsAsset::WalletEthereumAsset(WalletEthereumAsset::Eth);
     let chain = WalletTransactionsChain::Base;
 
     let transactions = debug_response!(client.wallets().transactions().get(
         &wallet_id,
-        &asset,
+        Some(&asset),
         chain,
         None,
         Some(10.0),
+        None,
         None
     ))
     .await?;
@@ -233,14 +240,14 @@ async fn test_wallets_balance_get() -> Result<()> {
     let client = get_test_client()?;
     let wallet_id = get_test_wallet_id_by_type(&client, WalletChainType::Solana, None).await?;
 
-    let asset = GetWalletBalanceAsset::String(GetWalletBalanceAssetString::Sol);
+    let asset = GetWalletBalanceAsset::WalletSolanaAsset(WalletSolanaAsset::Sol);
     let chain = GetWalletBalanceChain::String(GetWalletBalanceChainString::Solana);
 
     let balance = debug_response!(
         client
             .wallets()
             .balance()
-            .get(&wallet_id, &asset, &chain, None)
+            .get(&wallet_id, Some(&asset), Some(&chain), None, None)
     )
     .await?;
 


### PR DESCRIPTION
## Summary

Update all wallet-related code (core library, tests, and examples) to match the regenerated OpenAPI types. This is the largest PR in the stack as wallets are the primary domain of the SDK.

### Core library changes:
- **src/ethereum.rs** — `UnsignedEthereumTransaction` is now a union type (enum) with `StandardEthereumTransaction` and `TempoTransaction` variants. String fields converted to validated newtypes (`Hex`, `Quantity`, `EthereumPersonalSignRpcInputParamsMessage`, etc.). RPC input structs gained `wallet_id: None` field.
- **src/solana.rs** — `WalletRpcBody` → `WalletRpcRequestBody`. String fields converted to newtypes (`Caip2`, `SolanaSignTransactionRpcInputParamsTransaction`, etc.). Added `optimistic_broadcast`, `reference_id` fields.
- **src/subclients/wallets.rs** — All internal method calls updated with `None` for new `privy_request_expiry` parameter. `RawSignInputResponse` → `RawSignResponse`.
- **src/import.rs** — Updated for new type signatures
- **src/jwt_exchange.rs** — Updated for new type signatures
- **src/utils.rs** — `OwnerInput` variants changed from named (`PublicKey`, `UserId`) to `Variant0(OwnerInputUser)`, `Variant1(OwnerInputPublicKey)`

### Test changes:
- **tests/wallets.rs** — All type renames, newtypes, union types, new method signatures
- **tests/common/mod.rs** — `CreateWalletBody` gained `display_name`, `external_id` fields; `policy_ids` → `Option<PolicyInput>`

### Example changes:
- All wallet examples updated for new type names and constructors

## Key breaking changes addressed

| Before | After |
|--------|-------|
| `UnsignedEthereumTransaction { ... }` | `UnsignedStandardEthereumTransaction { ... }.into()` |
| `"0x..."` string literals | `.parse::<Hex>().unwrap()` newtypes |
| `OwnerInput::PublicKey { ... }` | `OwnerInput::Variant1(OwnerInputPublicKey { ... })` |
| `WalletRpcBody` | `WalletRpcRequestBody` |
| `RawSignInputResponse` | `RawSignResponse` |

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes (on full stack)
- [x] All wallet tests pass against staging API
- [x] Examples compile and demonstrate correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)