### PR TITLE
fix: update transaction and user tests for regenerated types

### DIFF
--- a/tests/transactions.rs
+++ b/tests/transactions.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use privy_rs::generated::types::{
-    WalletChainType, WalletTransactionsAsset, WalletTransactionsAssetString,
-    WalletTransactionsChain,
+    WalletChainType, WalletSolanaAsset, WalletTransactionsAsset, WalletTransactionsChain,
 };
 
 mod common;
@@ -18,11 +17,12 @@ async fn test_transactions_get() -> Result<()> {
     // Get the first transaction from wallet transactions
     let transactions_response = debug_response!(client.wallets().transactions().get(
         &wallet_id,
-        &WalletTransactionsAsset::String(WalletTransactionsAssetString::Sol),
+        Some(&WalletTransactionsAsset::WalletSolanaAsset(WalletSolanaAsset::Sol)),
         WalletTransactionsChain::Base,
         None,      // No cursor for first page
         Some(1.0), // Limit to 1 transaction to get one ID,
         None,
+        None,      // No tx_hash filter
     ))
     .await?;
 

--- a/tests/users.rs
+++ b/tests/users.rs
@@ -2,9 +2,9 @@ use std::{collections::HashMap, time::SystemTime};
 
 use anyhow::Result;
 use privy_rs::generated::types::{
-    CreateUserBody, CreateUserWalletBody, CreateUserWalletBodyWalletsItem, CustomMetadataValue,
-    LinkedAccount, LinkedAccountEmailInput, LinkedAccountEmailInputType, LinkedAccountInput,
-    SearchUsersBody, UpdateUserCustomMetadataBody, WalletChainType,
+    CreateUserBody, CreateUserWalletBody, CustomMetadataValue, LinkedAccount,
+    LinkedAccountEmailInput, LinkedAccountEmailInputType, LinkedAccountInput, SearchUsersBody,
+    UpdateUserCustomMetadataBody, WalletChainType, WalletCreationInput,
 };
 use tracing_test::traced_test;
 
@@ -124,7 +124,7 @@ async fn test_users_pregenerate_wallets() -> Result<()> {
     let user_id = common::ensure_test_user(&client).await?.id;
 
     let pregenerate_body = CreateUserWalletBody {
-        wallets: vec![CreateUserWalletBodyWalletsItem {
+        wallets: vec![WalletCreationInput {
             chain_type: WalletChainType::Ethereum,
             additional_signers: vec![],
             create_smart_wallet: None,


### PR DESCRIPTION
## Summary

Update remaining test files for regenerated types. These are the final changes in the stack — after this PR, the full SDK compiles cleanly with all tests updated.

### Test changes:
- **tests/transactions.rs** — `WalletTransactionsAsset` enum variants updated for new naming, new method parameters added
- **tests/users.rs** — `CreateUserWalletBodyWalletsItem` renamed to `WalletCreationInput`

## Key breaking changes addressed

| Before | After |
|--------|-------|
| `CreateUserWalletBodyWalletsItem` | `WalletCreationInput` |
| Old `WalletTransactionsAsset` variants | Updated variant names |

## Verification

✅ `cargo clippy --all-targets --all-features -- -D warnings` passes on this PR (top of stack)

## Test plan

- [ ] Full test suite passes against staging API
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — verified passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)