### PR TITLE
ci: run test workflow on all pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main, arlyon/next]
   pull_request:
-    branches: [main, arlyon/next]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Remove the `branches` filter from the `pull_request` trigger in CI so tests run on all PRs regardless of base branch.

Previously, CI only ran on PRs targeting `main` or `arlyon/next`. This meant stacked PRs (where intermediate PRs target other feature branches) never got CI coverage.

## Test plan

- [ ] After merge, verify CI triggers on PRs in the openapi regeneration stack (#120-#125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)