### PR TITLE
ci: refresh CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, arlyon/next]
+    branches: [main]
   pull_request:
 
 env:
@@ -49,8 +49,14 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Run tests
         run: cargo test --verbose
 
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Compile examples
+        run: cargo test --examples --no-run
+
+      - name: Run doc tests
+        run: cargo test --doc


### PR DESCRIPTION
## Summary
- Remove stale `arlyon/next` branch from push trigger
- Add example compilation check (`cargo test --examples --no-run`)
- Add explicit doc test step (`cargo test --doc`)
- Move clippy before tests for faster feedback on lint failures

Closes the concept from #77 (closed as stale) with a simpler approach.

## Test plan
- [x] CI runs successfully on this PR
- [x] Examples are compile-checked
- [x] Doc tests run explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)